### PR TITLE
feat: solidity unit test coverage

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,7 @@
+module.exports = {
+    skipFiles: ['test', 'utils/MockAxelarGateway.sol'],
+    mocha: {
+        grep: "@skip-on-coverage", // Add to test description to skip coverage from being run some tests, such as bytecode checks
+        invert: true,
+    },
+};

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -14,12 +14,12 @@ module.exports = {
                 enabled: true,
                 runs: 1000,
                 details: {
-                    peephole: true,
-                    inliner: true,
+                    peephole: process.env.COVERAGE === undefined,
+                    inliner: process.env.COVERAGE === undefined,
                     jumpdestRemover: true,
                     orderLiterals: true,
                     deduplicate: true,
-                    cse: true,
+                    cse: process.env.COVERAGE === undefined,
                     constantOptimizer: true,
                     yul: true,
                     yulDetails: {


### PR DESCRIPTION
Generate unit test coverage report via:
`COVERAGE=true npx hardhat coverage`

To view the report
`open ./coverage/index.html`

For coverage to work correctly, some optimizations need to skipped