### PR TITLE
chore: add repository link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@axelar-network/interchain-token-service",
   "version": "0.3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/axelarnetwork/interchain-token-service"
+  },
   "main": "index.js",
   "scripts": {
     "test": "npx hardhat test",


### PR DESCRIPTION
This lets package managers like NPM link back to this repository.