### PR TITLE
feat: remove liquidity pool token manager from ITS

### DIFF
--- a/contracts/interchain-token-service/InterchainTokenService.sol
+++ b/contracts/interchain-token-service/InterchainTokenService.sol
@@ -51,7 +51,6 @@ contract InterchainTokenService is
     address internal immutable implementationMintBurn;
     address internal immutable implementationMintBurnFrom;
     address internal immutable implementationLockUnlockFee;
-    address internal immutable implementationLiquidityPool;
     IAxelarGateway public immutable gateway;
     IAxelarGasService public immutable gasService;
     IRemoteAddressValidator public immutable remoteAddressValidator;
@@ -77,7 +76,7 @@ contract InterchainTokenService is
      * @param gateway_ the address of the AxelarGateway.
      * @param gasService_ the address of the AxelarGasService.
      * @param remoteAddressValidator_ the address of the RemoteAddressValidator.
-     * @param tokenManagerImplementations this needs to have implementations in the order: Mint-burn, Mint-burn from, Lock-unlock, Lock-unlock with fee, and liquidity pool.
+     * @param tokenManagerImplementations this needs to have implementations in the order: Mint-burn, Mint-burn from, Lock-unlock, and Lock-unlock with fee.
      */
     constructor(
         address tokenManagerDeployer_,
@@ -107,7 +106,6 @@ contract InterchainTokenService is
         implementationMintBurnFrom = _sanitizeTokenManagerImplementation(tokenManagerImplementations, TokenManagerType.MINT_BURN_FROM);
         implementationLockUnlock = _sanitizeTokenManagerImplementation(tokenManagerImplementations, TokenManagerType.LOCK_UNLOCK);
         implementationLockUnlockFee = _sanitizeTokenManagerImplementation(tokenManagerImplementations, TokenManagerType.LOCK_UNLOCK_FEE);
-        implementationLiquidityPool = _sanitizeTokenManagerImplementation(tokenManagerImplementations, TokenManagerType.LIQUIDITY_POOL);
         string memory chainName_ = remoteAddressValidator.chainName();
         chainNameHash = keccak256(bytes(chainName_));
     }
@@ -220,7 +218,6 @@ contract InterchainTokenService is
         if (TokenManagerType(tokenManagerType) == TokenManagerType.MINT_BURN_FROM) return implementationMintBurnFrom;
         if (TokenManagerType(tokenManagerType) == TokenManagerType.LOCK_UNLOCK) return implementationLockUnlock;
         if (TokenManagerType(tokenManagerType) == TokenManagerType.LOCK_UNLOCK_FEE) return implementationLockUnlockFee;
-        if (TokenManagerType(tokenManagerType) == TokenManagerType.LIQUIDITY_POOL) return implementationLiquidityPool;
 
         revert InvalidImplementation();
     }

--- a/contracts/interfaces/ITokenManagerType.sol
+++ b/contracts/interfaces/ITokenManagerType.sol
@@ -11,7 +11,6 @@ interface ITokenManagerType {
         MINT_BURN,
         MINT_BURN_FROM,
         LOCK_UNLOCK,
-        LOCK_UNLOCK_FEE,
-        LIQUIDITY_POOL
+        LOCK_UNLOCK_FEE
     }
 }

--- a/contracts/token-manager/implementations/TokenManagerLiquidityPool.sol
+++ b/contracts/token-manager/implementations/TokenManagerLiquidityPool.sol
@@ -30,7 +30,7 @@ contract TokenManagerLiquidityPool is TokenManager, NoReEntrancy, ITokenManagerL
     constructor(address interchainTokenService_) TokenManager(interchainTokenService_) {}
 
     function implementationType() external pure returns (uint256) {
-        return uint256(TokenManagerType.LIQUIDITY_POOL);
+        revert('Not supported');
     }
 
     /**

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -66,7 +66,7 @@ async function deployInterchainTokenService(
 async function deployTokenManagerImplementations(wallet, interchainTokenServiceAddress) {
     const implementations = [];
 
-    for (const type of ['MintBurn', 'MintBurnFrom', 'LockUnlock', 'LockUnlockFee', 'LiquidityPool']) {
+    for (const type of ['MintBurn', 'MintBurnFrom', 'LockUnlock', 'LockUnlockFee']) {
         const impl = await deployContract(wallet, `TokenManager${type}`, [interchainTokenServiceAddress]);
         implementations.push(impl);
     }
@@ -96,6 +96,7 @@ async function deployAll(wallet, chainName, evmChains = [], deploymentKey = 'int
         tokenManagerImplementations.map((impl) => impl.address),
         deploymentKey,
     );
+
     return [service, gateway, gasService];
 }
 

--- a/test/TokenService.js
+++ b/test/TokenService.js
@@ -8,7 +8,6 @@ const { AddressZero, MaxUint256 } = ethers.constants;
 const { defaultAbiCoder, solidityPack, keccak256, arrayify } = ethers.utils;
 const { Contract, Wallet } = ethers;
 const TokenManager = require('../artifacts/contracts/token-manager/TokenManager.sol/TokenManager.json');
-const TokenManagerLiquidityPool = require('../artifacts/contracts/token-manager/implementations/TokenManagerLiquidityPool.sol/TokenManagerLiquidityPool.json');
 const Token = require('../artifacts/contracts/interfaces/IStandardizedToken.sol/IStandardizedToken.json');
 const { getCreate3Address } = require('@axelar-network/axelar-gmp-sdk-solidity');
 const { approveContractCall } = require('../scripts/utils');
@@ -33,10 +32,9 @@ const MINT_BURN = 0;
 const MINT_BURN_FROM = 1;
 const LOCK_UNLOCK = 2;
 const LOCK_UNLOCK_FEE_ON_TRANSFER = 3;
-const LIQUIDITY_POOL = 4;
 
 describe('Interchain Token Service', () => {
-    let wallet, liquidityPool, otherWallet;
+    let wallet, otherWallet;
     let service, gateway, gasService;
 
     const deployFunctions = {};
@@ -118,36 +116,10 @@ describe('Interchain Token Service', () => {
     deployFunctions.mintBurn = makeDeployNewMintBurn(MINT_BURN);
     deployFunctions.mintBurnFrom = makeDeployNewMintBurn(MINT_BURN_FROM);
 
-    deployFunctions.liquidityPool = async function deployNewLiquidityPool(
-        tokenName,
-        tokenSymbol,
-        tokenDecimals,
-        mintAmount = 0,
-        skipApprove = false,
-    ) {
-        const salt = getRandomBytes32();
-        const tokenId = await service.getCustomTokenId(wallet.address, salt);
-        const tokenManager = new Contract(await service.getTokenManagerAddress(tokenId), TokenManager.abi, wallet);
-
-        const token = await deployContract(wallet, 'InterchainTokenTest', [tokenName, tokenSymbol, tokenDecimals, tokenManager.address]);
-        const params = defaultAbiCoder.encode(['bytes', 'address', 'address'], [wallet.address, token.address, liquidityPool.address]);
-
-        await (await service.deployCustomTokenManager(salt, LIQUIDITY_POOL, params)).wait();
-        await (await token.connect(liquidityPool).approve(tokenManager.address, MaxUint256)).wait();
-
-        if (mintAmount > 0) {
-            await (await token.mint(wallet.address, mintAmount)).wait();
-            if (!skipApprove) await (await token.approve(tokenManager.address, mintAmount)).wait();
-        }
-
-        return [token, tokenManager, tokenId];
-    };
-
     before(async () => {
         const wallets = await ethers.getSigners();
         wallet = wallets[0];
-        liquidityPool = wallets[1];
-        otherWallet = wallets[2];
+        otherWallet = wallets[1];
         [service, gateway, gasService] = await deployAll(wallet, 'Test', [sourceChain, destinationChain]);
     });
 
@@ -411,7 +383,7 @@ describe('Interchain Token Service', () => {
         });
 
         it('Should revert on pausing if not the owner', async () => {
-            await expectRevert((gasOptions) => service.connect(liquidityPool).setPaused(true, gasOptions), service, 'NotOwner');
+            await expectRevert((gasOptions) => service.connect(otherWallet).setPaused(true, gasOptions), service, 'NotOwner');
         });
 
         it('Should revert on get token manager if token manager does not exist', async () => {
@@ -1035,56 +1007,6 @@ describe('Interchain Token Service', () => {
             expect(tokenAddress).to.eq(token.address);
         });
 
-        it('Should deploy a liquidity pool token manager', async () => {
-            const tokenName = 'Token Name';
-            const tokenSymbol = 'TN';
-            const tokenDecimals = 13;
-            const salt = getRandomBytes32();
-            const tokenId = await service.getCustomTokenId(wallet.address, salt);
-            const tokenManagerAddress = await service.getTokenManagerAddress(tokenId);
-            const token = await deployContract(wallet, 'InterchainTokenTest', [tokenName, tokenSymbol, tokenDecimals, tokenManagerAddress]);
-            const params = defaultAbiCoder.encode(['bytes', 'address', 'address'], [wallet.address, token.address, liquidityPool.address]);
-
-            const tx = service.deployCustomTokenManager(salt, LIQUIDITY_POOL, params);
-            await expect(tx).to.emit(service, 'TokenManagerDeployed').withArgs(tokenId, LIQUIDITY_POOL, params);
-
-            expect(tokenManagerAddress).to.not.equal(AddressZero);
-            const tokenManager = new Contract(tokenManagerAddress, TokenManager.abi, wallet);
-
-            expect(await tokenManager.operator()).to.equal(wallet.address);
-
-            const tokenAddress = await service.getTokenAddress(tokenId);
-            expect(tokenAddress).to.eq(token.address);
-        });
-
-        it('Should allow operator to change the liquidity pool address', async () => {
-            const tokenName = 'Token Name';
-            const tokenSymbol = 'TN';
-            const tokenDecimals = 13;
-            const salt = getRandomBytes32();
-            const tokenId = await service.getCustomTokenId(wallet.address, salt);
-            const tokenManagerAddress = await service.getTokenManagerAddress(tokenId);
-            const token = await deployContract(wallet, 'InterchainTokenTest', [tokenName, tokenSymbol, tokenDecimals, tokenManagerAddress]);
-            const params = defaultAbiCoder.encode(['bytes', 'address', 'address'], [wallet.address, token.address, liquidityPool.address]);
-
-            const tx = service.deployCustomTokenManager(salt, LIQUIDITY_POOL, params);
-            await expect(tx).to.emit(service, 'TokenManagerDeployed').withArgs(tokenId, LIQUIDITY_POOL, params);
-
-            expect(tokenManagerAddress).to.not.equal(AddressZero);
-            const tokenManagerLiquidityPool = new Contract(tokenManagerAddress, TokenManagerLiquidityPool.abi, wallet);
-
-            expectRevert(
-                (gasOptions) => tokenManagerLiquidityPool.connect(otherWallet).setLiquidityPool(otherWallet.address, gasOptions),
-                tokenManagerLiquidityPool,
-                'NotOperator',
-            );
-
-            await tokenManagerLiquidityPool.setLiquidityPool(otherWallet.address).then((tx) => tx.wait());
-
-            const newLiquidityPool = await tokenManagerLiquidityPool.liquidityPool();
-            expect(newLiquidityPool).to.eq(otherWallet.address);
-        });
-
         it('Should revert when deploying a custom token manager twice', async () => {
             const tokenName = 'Token Name';
             const tokenSymbol = 'TN';
@@ -1279,29 +1201,6 @@ describe('Interchain Token Service', () => {
             expect(await tokenManager.tokenAddress()).to.equal(token.address);
             expect(await tokenManager.operator()).to.equal(wallet.address);
         });
-
-        it('Should be able to receive a remote liquidity pool token manager depoloyment', async () => {
-            const tokenName = 'Token Name';
-            const tokenSymbol = 'TN';
-            const tokenDecimals = 13;
-            const tokenId = getRandomBytes32();
-            const tokenManagerAddress = await service.getTokenManagerAddress(tokenId);
-            const token = await deployContract(wallet, 'InterchainTokenTest', [tokenName, tokenSymbol, tokenDecimals, tokenManagerAddress]);
-
-            const params = defaultAbiCoder.encode(['bytes', 'address', 'address'], [wallet.address, token.address, liquidityPool.address]);
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'uint256', 'bytes'],
-                [SELECTOR_DEPLOY_TOKEN_MANAGER, tokenId, LIQUIDITY_POOL, params],
-            );
-            const commandId = await approveContractCall(gateway, sourceChain, sourceAddress, service.address, payload);
-
-            await expect(service.execute(commandId, sourceChain, sourceAddress, payload))
-                .to.emit(service, 'TokenManagerDeployed')
-                .withArgs(tokenId, LIQUIDITY_POOL, params);
-            const tokenManager = new Contract(tokenManagerAddress, TokenManager.abi, wallet);
-            expect(await tokenManager.tokenAddress()).to.equal(token.address);
-            expect(await tokenManager.operator()).to.equal(wallet.address);
-        });
     });
 
     describe('Send Token', () => {
@@ -1309,7 +1208,7 @@ describe('Interchain Token Service', () => {
         const destAddress = '0x5678';
         const gasValue = 90;
 
-        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee', 'liquidityPool']) {
+        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee']) {
             it(`Should be able to initiate an interchain token transfer [${type}]`, async () => {
                 const [token, tokenManager, tokenId] = await deployFunctions[type](`Test Token ${type}`, 'TT', 12, amount);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
@@ -1323,8 +1222,6 @@ describe('Interchain Token Service', () => {
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
                     transferToAddress = tokenManager.address;
-                } else if (type === 'liquidityPool') {
-                    transferToAddress = liquidityPool.address;
                 }
 
                 await expect(tokenManager.interchainTransfer(destinationChain, destAddress, amount, '0x', { value: gasValue }))
@@ -1499,22 +1396,6 @@ describe('Interchain Token Service', () => {
                 .and.to.emit(service, 'TokenReceived')
                 .withArgs(tokenId, sourceChain, destAddress, amount - 10);
         });
-
-        it('Should be able to receive liquidity pool token', async () => {
-            const [token, , tokenId] = await deployFunctions.liquidityPool(`Test Token Liquidity Pool`, 'TTLP', 12, amount);
-            (await await token.transfer(liquidityPool.address, amount)).wait();
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'bytes', 'uint256'],
-                [SELECTOR_SEND_TOKEN, tokenId, destAddress, amount],
-            );
-            const commandId = await approveContractCall(gateway, sourceChain, sourceAddress, service.address, payload);
-
-            await expect(service.execute(commandId, sourceChain, sourceAddress, payload))
-                .to.emit(token, 'Transfer')
-                .withArgs(liquidityPool.address, destAddress, amount)
-                .and.to.emit(service, 'TokenReceived')
-                .withArgs(tokenId, sourceChain, destAddress, amount);
-        });
     });
 
     describe('Send Token With Data', () => {
@@ -1528,7 +1409,7 @@ describe('Interchain Token Service', () => {
             sourceAddress = wallet.address;
         });
 
-        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee', 'liquidityPool']) {
+        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee']) {
             it(`Should be able to initiate an interchain token transfer [${type}]`, async () => {
                 const [token, tokenManager, tokenId] = await deployFunctions[type](`Test Token ${type}`, 'TT', 12, amount);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
@@ -1542,8 +1423,6 @@ describe('Interchain Token Service', () => {
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
                     transferToAddress = tokenManager.address;
-                } else if (type === 'liquidityPool') {
-                    transferToAddress = liquidityPool.address;
                 }
 
                 await expect(tokenManager.callContractWithInterchainToken(destinationChain, destAddress, amount, data, { value: gasValue }))
@@ -1558,7 +1437,7 @@ describe('Interchain Token Service', () => {
             });
         }
 
-        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee', 'liquidityPool']) {
+        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee']) {
             it(`Should be able to initiate an interchain token transfer via the interchainTransfer function on the service [${type}]`, async () => {
                 const [token, tokenManager, tokenId] = await deployFunctions[type](`Test Token ${type}`, 'TT', 12, amount);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
@@ -1573,8 +1452,6 @@ describe('Interchain Token Service', () => {
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
                     transferToAddress = tokenManager.address;
-                } else if (type === 'liquidityPool') {
-                    transferToAddress = liquidityPool.address;
                 }
 
                 await expect(service.interchainTransfer(tokenId, destinationChain, destAddress, amount, metadata))
@@ -1587,7 +1464,7 @@ describe('Interchain Token Service', () => {
             });
         }
 
-        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee', 'liquidityPool']) {
+        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee']) {
             it(`Should be able to initiate an interchain token transfer via the sendTokenWithData function on the service [${type}]`, async () => {
                 const [token, tokenManager, tokenId] = await deployFunctions[type](`Test Token ${type}`, 'TT', 12, amount);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
@@ -1601,8 +1478,6 @@ describe('Interchain Token Service', () => {
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
                     transferToAddress = tokenManager.address;
-                } else if (type === 'liquidityPool') {
-                    transferToAddress = liquidityPool.address;
                 }
 
                 await expect(service.sendTokenWithData(tokenId, destinationChain, destAddress, amount, data))
@@ -1712,30 +1587,6 @@ describe('Interchain Token Service', () => {
 
             expect(await executable.lastMessage()).to.equal(msg);
         });
-
-        it('Should be able to receive liquidity pool token', async () => {
-            const [token, , tokenId] = await deployFunctions.liquidityPool(`Test Token Liquidity Pool`, 'TTLP', 12, amount);
-            (await await token.transfer(liquidityPool.address, amount)).wait();
-            const msg = `mint/burn`;
-            const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'bytes', 'uint256', 'bytes', 'bytes'],
-                [SELECTOR_SEND_TOKEN_WITH_DATA, tokenId, destAddress, amount, sourceAddressForService, data],
-            );
-            const commandId = await approveContractCall(gateway, sourceChain, sourceAddress, service.address, payload);
-
-            await expect(service.execute(commandId, sourceChain, sourceAddress, payload))
-                .to.emit(token, 'Transfer')
-                .withArgs(liquidityPool.address, destAddress, amount)
-                .to.emit(token, 'Transfer')
-                .withArgs(destAddress, wallet.address, amount)
-                .and.to.emit(service, 'TokenReceivedWithData')
-                .withArgs(tokenId, sourceChain, destAddress, amount, sourceAddressForService, data)
-                .and.to.emit(executable, 'MessageReceived')
-                .withArgs(sourceChain, sourceAddressForService, wallet.address, msg, tokenId, amount);
-
-            expect(await executable.lastMessage()).to.equal(msg);
-        });
     });
 
     describe('Send Interchain Token', () => {
@@ -1744,7 +1595,7 @@ describe('Interchain Token Service', () => {
         const gasValue = 90;
         const metadata = '0x';
 
-        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee', 'liquidityPool']) {
+        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee']) {
             it(`Should be able to initiate an interchain token transfer [${type}]`, async () => {
                 const [token, tokenManager, tokenId] = await deployFunctions[type](`Test Token ${type}`, 'TT', 12, amount, true);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
@@ -1758,8 +1609,6 @@ describe('Interchain Token Service', () => {
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
                     transferToAddress = tokenManager.address;
-                } else if (type === 'liquidityPool') {
-                    transferToAddress = liquidityPool.address;
                 }
 
                 await expect(token.interchainTransfer(destinationChain, destAddress, amount, metadata, { value: gasValue }))
@@ -1786,8 +1635,6 @@ describe('Interchain Token Service', () => {
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
                     transferToAddress = tokenManager.address;
-                } else if (type === 'liquidityPool') {
-                    transferToAddress = liquidityPool.address;
                 }
 
                 const sender = wallet;
@@ -1852,7 +1699,7 @@ describe('Interchain Token Service', () => {
             sourceAddress = wallet.address;
         });
 
-        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee', 'liquidityPool']) {
+        for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee']) {
             it(`Should be able to initiate an interchain token transfer [${type}]`, async () => {
                 const [token, tokenManager, tokenId] = await deployFunctions[type](`Test Token ${type}`, 'TT', 12, amount, false);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
@@ -1867,8 +1714,6 @@ describe('Interchain Token Service', () => {
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
                     transferToAddress = tokenManager.address;
-                } else if (type === 'liquidityPool') {
-                    transferToAddress = liquidityPool.address;
                 }
 
                 const metadata = solidityPack(['uint32', 'bytes'], [0, data]);
@@ -2041,26 +1886,6 @@ describe('Interchain Token Service', () => {
                 .and.to.emit(service, 'ExpressExecutionFulfilled')
                 .withArgs(payload, commandId, wallet.address);
         });
-
-        it('Should be able to receive liquidity pool token', async () => {
-            const [token, , tokenId] = await deployFunctions.liquidityPool(`Test Token Liquidity Pool`, 'TTLP', 12, amount * 2);
-            await (await token.transfer(liquidityPool.address, amount)).wait();
-            await (await token.approve(service.address, amount)).wait();
-
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'bytes', 'uint256'],
-                [SELECTOR_SEND_TOKEN, tokenId, destAddress, amount],
-            );
-            const commandId = await approveContractCall(gateway, sourceChain, sourceAddress, service.address, payload);
-
-            await (await service.expressReceiveToken(payload, commandId, sourceChain)).wait();
-
-            await expect(service.execute(commandId, sourceChain, sourceAddress, payload))
-                .to.emit(token, 'Transfer')
-                .withArgs(liquidityPool.address, wallet.address, amount)
-                .and.to.emit(service, 'ExpressExecutionFulfilled')
-                .withArgs(payload, commandId, wallet.address);
-        });
     });
 
     describe('Express Receive Remote Tokens with Data', () => {
@@ -2140,30 +1965,6 @@ describe('Interchain Token Service', () => {
 
             await expect(service.expressReceiveToken(payload, commandId, sourceChain)).to.be.reverted;
         });
-
-        it('Should be able to receive liquidity pool token', async () => {
-            const [token, , tokenId] = await deployFunctions.liquidityPool(`Test Token Liquidity Pool`, 'TTLP', 12, amount * 2);
-            (await await token.transfer(liquidityPool.address, amount)).wait();
-            await (await token.approve(service.address, amount)).wait();
-
-            const msg = `mint/burn`;
-            const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'bytes', 'uint256', 'bytes', 'bytes'],
-                [SELECTOR_SEND_TOKEN_WITH_DATA, tokenId, destAddress, amount, sourceAddressForService, data],
-            );
-            const commandId = await approveContractCall(gateway, sourceChain, sourceAddress, service.address, payload);
-
-            await (await service.expressReceiveToken(payload, commandId, sourceChain)).wait();
-
-            await expect(service.execute(commandId, sourceChain, sourceAddress, payload))
-                .to.emit(token, 'Transfer')
-                .withArgs(liquidityPool.address, wallet.address, amount)
-                .and.to.emit(service, 'ExpressExecutionFulfilled')
-                .withArgs(payload, commandId, wallet.address);
-
-            expect(await executable.lastMessage()).to.equal(msg);
-        });
     });
 
     describe('Flow Limits', () => {
@@ -2220,10 +2021,9 @@ describe('Interchain Token Service', () => {
 
         it('Should be able to set flow limits for each token manager', async () => {
             const tokenIds = [];
-            const flowLimits = new Array(4).fill(flowLimit);
             const tokenManagers = [];
 
-            for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee', 'liquidityPool']) {
+            for (const type of ['lockUnlock', 'mintBurn', 'lockUnlockFee']) {
                 const [, tokenManager, tokenId] = await deployFunctions[type](`Test Token ${type}`, 'TT', 12, mintAmount);
                 tokenIds.push(tokenId);
                 tokenManagers.push(tokenManager);
@@ -2231,8 +2031,10 @@ describe('Interchain Token Service', () => {
                 await tokenManager.transferOperatorship(service.address).then((tx) => tx.wait());
             }
 
+            const flowLimits = new Array(tokenManagers.length).fill(flowLimit);
+
             await expectRevert(
-                (gasOptions) => service.connect(liquidityPool).setFlowLimits(tokenIds, flowLimits, gasOptions),
+                (gasOptions) => service.connect(otherWallet).setFlowLimits(tokenIds, flowLimits, gasOptions),
                 service,
                 'NotOperator',
             );
@@ -2243,8 +2045,6 @@ describe('Interchain Token Service', () => {
                 .to.emit(tokenManagers[1], 'FlowLimitSet')
                 .withArgs(flowLimit)
                 .to.emit(tokenManagers[2], 'FlowLimitSet')
-                .withArgs(flowLimit)
-                .to.emit(tokenManagers[3], 'FlowLimitSet')
                 .withArgs(flowLimit);
 
             flowLimits.pop();


### PR DESCRIPTION
PR to remove the liquidity pool token manager implementation type from `InterchainTokenService` as per [AXE-2063](https://axelarnetwork.atlassian.net/jira/software/c/projects/AXE/boards/21?selectedIssue=AXE-2063)

[AXE-2063]: https://axelarnetwork.atlassian.net/browse/AXE-2063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ