### PR TITLE
refactor: rename token standard interface

### DIFF
--- a/contracts/interchain-token/BaseInterchainToken.sol
+++ b/contracts/interchain-token/BaseInterchainToken.sol
@@ -2,17 +2,17 @@
 
 pragma solidity ^0.8.0;
 
-import { IInterchainTokenBase } from '../interfaces/IInterchainTokenBase.sol';
+import { IInterchainTokenStandard } from '../interfaces/IInterchainTokenStandard.sol';
 import { ITokenManager } from '../interfaces/ITokenManager.sol';
 
 import { ERC20 } from './ERC20.sol';
 
 /**
- * @title An example implementation of the IInterchainToken.
+ * @title An example implementation of the IInterchainTokenStandard.
  * @notice The implementation ERC20 can be done in any way, however this example assumes that an _approve internal function exists
  * that can be used to create approvals, and that `allowance` is a mapping.
  */
-abstract contract InterchainTokenBase is IInterchainTokenBase, ERC20 {
+abstract contract BaseInterchainToken is IInterchainTokenStandard, ERC20 {
     /**
      * @notice Getter for the tokenManager used for this token.
      * @dev Needs to be overwritten.

--- a/contracts/interchain-token/BaseInterchainToken.sol
+++ b/contracts/interchain-token/BaseInterchainToken.sol
@@ -18,7 +18,7 @@ abstract contract BaseInterchainToken is IInterchainTokenStandard, ERC20 {
      * @dev Needs to be overwritten.
      * @return tokenManager_ the TokenManager called to facilitate cross chain transfers.
      */
-    function tokenManager() public view virtual returns (ITokenManager tokenManager_);
+    function tokenManager() public view virtual returns (address tokenManager_);
 
     /**
      * @notice Implementation of the interchainTransfer method
@@ -39,7 +39,7 @@ abstract contract BaseInterchainToken is IInterchainTokenStandard, ERC20 {
 
         _beforeInterchainTransfer(msg.sender, destinationChain, recipient, amount, metadata);
 
-        ITokenManager tokenManager_ = tokenManager();
+        ITokenManager tokenManager_ = ITokenManager(tokenManager());
         tokenManager_.transmitInterchainTransfer{ value: msg.value }(sender, destinationChain, recipient, amount, metadata);
     }
 
@@ -68,7 +68,7 @@ abstract contract BaseInterchainToken is IInterchainTokenStandard, ERC20 {
 
         _beforeInterchainTransfer(sender, destinationChain, recipient, amount, metadata);
 
-        ITokenManager tokenManager_ = tokenManager();
+        ITokenManager tokenManager_ = ITokenManager(tokenManager());
         tokenManager_.transmitInterchainTransfer{ value: msg.value }(sender, destinationChain, recipient, amount, metadata);
     }
 

--- a/contracts/interchain-token/InterchainToken.sol
+++ b/contracts/interchain-token/InterchainToken.sol
@@ -7,7 +7,6 @@ import { IImplementation } from '@axelar-network/axelar-gmp-sdk-solidity/contrac
 import { Implementation } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/upgradable/Implementation.sol';
 
 import { IInterchainToken } from '../interfaces/IInterchainToken.sol';
-import { ITokenManager } from '../interfaces/ITokenManager.sol';
 
 import { BaseInterchainToken } from './BaseInterchainToken.sol';
 import { ERC20Permit } from './ERC20Permit.sol';
@@ -37,7 +36,7 @@ contract InterchainToken is BaseInterchainToken, ERC20Permit, Implementation, Di
 
     /**
      * @notice Returns the token manager for this token
-     * @return ITokenManager The token manager contract
+     * @return address The token manager contract
      */
     function tokenManager() public view override(BaseInterchainToken, IInterchainToken) returns (address) {
         return tokenManager_;

--- a/contracts/interchain-token/InterchainToken.sol
+++ b/contracts/interchain-token/InterchainToken.sol
@@ -9,7 +9,7 @@ import { Implementation } from '@axelar-network/axelar-gmp-sdk-solidity/contract
 import { IInterchainToken } from '../interfaces/IInterchainToken.sol';
 import { ITokenManager } from '../interfaces/ITokenManager.sol';
 
-import { InterchainTokenBase } from './InterchainTokenBase.sol';
+import { BaseInterchainToken } from './BaseInterchainToken.sol';
 import { ERC20Permit } from './ERC20Permit.sol';
 import { Distributable } from '../utils/Distributable.sol';
 
@@ -18,7 +18,7 @@ import { Distributable } from '../utils/Distributable.sol';
  * @notice This contract implements a interchain token which extends InterchainToken functionality.
  * This contract also inherits Distributable and Implementation logic.
  */
-contract InterchainToken is InterchainTokenBase, ERC20Permit, Implementation, Distributable, IInterchainToken {
+contract InterchainToken is BaseInterchainToken, ERC20Permit, Implementation, Distributable, IInterchainToken {
     using AddressBytes for bytes;
 
     string public name;
@@ -39,7 +39,7 @@ contract InterchainToken is InterchainTokenBase, ERC20Permit, Implementation, Di
      * @notice Returns the token manager for this token
      * @return ITokenManager The token manager contract
      */
-    function tokenManager() public view override(InterchainTokenBase, IInterchainToken) returns (ITokenManager) {
+    function tokenManager() public view override(BaseInterchainToken, IInterchainToken) returns (ITokenManager) {
         return ITokenManager(tokenManager_);
     }
 

--- a/contracts/interchain-token/InterchainToken.sol
+++ b/contracts/interchain-token/InterchainToken.sol
@@ -39,8 +39,8 @@ contract InterchainToken is BaseInterchainToken, ERC20Permit, Implementation, Di
      * @notice Returns the token manager for this token
      * @return ITokenManager The token manager contract
      */
-    function tokenManager() public view override(BaseInterchainToken, IInterchainToken) returns (ITokenManager) {
-        return ITokenManager(tokenManager_);
+    function tokenManager() public view override(BaseInterchainToken, IInterchainToken) returns (address) {
+        return tokenManager_;
     }
 
     /**

--- a/contracts/interfaces/IInterchainToken.sol
+++ b/contracts/interfaces/IInterchainToken.sol
@@ -7,7 +7,6 @@ import { IImplementation } from '@axelar-network/axelar-gmp-sdk-solidity/contrac
 import { IInterchainTokenStandard } from './IInterchainTokenStandard.sol';
 import { IDistributable } from './IDistributable.sol';
 import { IERC20MintableBurnable } from './IERC20MintableBurnable.sol';
-import { ITokenManager } from './ITokenManager.sol';
 import { IERC20Named } from './IERC20Named.sol';
 
 /**
@@ -22,5 +21,5 @@ interface IInterchainToken is IInterchainTokenStandard, IDistributable, IERC20Mi
      * @dev Needs to be overwitten.
      * @return tokenManager_ the TokenManager called to facilitate cross chain transfers.
      */
-    function tokenManager() external view returns (ITokenManager tokenManager_);
+    function tokenManager() external view returns (address tokenManager_);
 }

--- a/contracts/interfaces/IInterchainToken.sol
+++ b/contracts/interfaces/IInterchainToken.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 import { IImplementation } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IImplementation.sol';
 
-import { IInterchainTokenBase } from './IInterchainTokenBase.sol';
+import { IInterchainTokenStandard } from './IInterchainTokenStandard.sol';
 import { IDistributable } from './IDistributable.sol';
 import { IERC20MintableBurnable } from './IERC20MintableBurnable.sol';
 import { ITokenManager } from './ITokenManager.sol';
@@ -13,7 +13,7 @@ import { IERC20Named } from './IERC20Named.sol';
 /**
  * @title IInterchainToken
  */
-interface IInterchainToken is IInterchainTokenBase, IDistributable, IERC20MintableBurnable, IERC20Named, IImplementation {
+interface IInterchainToken is IInterchainTokenStandard, IDistributable, IERC20MintableBurnable, IERC20Named, IImplementation {
     error TokenManagerAddressZero();
     error TokenNameEmpty();
 

--- a/contracts/interfaces/IInterchainTokenStandard.sol
+++ b/contracts/interfaces/IInterchainTokenStandard.sol
@@ -2,19 +2,10 @@
 
 pragma solidity ^0.8.0;
 
-import { ITokenManager } from './ITokenManager.sol';
-
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.
  */
-interface IInterchainTokenBase {
-    /**
-     * @notice Getter for the tokenManager used for this token.
-     * @dev Needs to be overwitten.
-     * @return tokenManager_ the TokenManager called to facilitate cross chain transfers.
-     */
-    function tokenManager() external view returns (ITokenManager tokenManager_);
-
+interface IInterchainTokenStandard {
     /**
      * @notice Implementation of the interchainTransfer method
      * @dev We chose to either pass `metadata` as raw data on a remote contract call, or, if no data is passed, just do a transfer.

--- a/contracts/test/FeeOnTransferTokenTest.sol
+++ b/contracts/test/FeeOnTransferTokenTest.sol
@@ -4,11 +4,10 @@ pragma solidity ^0.8.0;
 
 import { BaseInterchainToken } from '../interchain-token/BaseInterchainToken.sol';
 import { Distributable } from '../utils/Distributable.sol';
-import { ITokenManager } from '../interfaces/ITokenManager.sol';
 import { IERC20MintableBurnable } from '../interfaces/IERC20MintableBurnable.sol';
 
 contract FeeOnTransferTokenTest is BaseInterchainToken, Distributable, IERC20MintableBurnable {
-    ITokenManager public tokenManager_;
+    address public tokenManager_;
     bool internal tokenManagerRequiresApproval_ = true;
 
     string public name;
@@ -20,10 +19,10 @@ contract FeeOnTransferTokenTest is BaseInterchainToken, Distributable, IERC20Min
         symbol = symbol_;
         decimals = decimals_;
         _addDistributor(msg.sender);
-        tokenManager_ = ITokenManager(tokenManagerAddress);
+        tokenManager_ = tokenManagerAddress;
     }
 
-    function tokenManager() public view override returns (ITokenManager) {
+    function tokenManager() public view override returns (address) {
         return tokenManager_;
     }
 
@@ -35,7 +34,7 @@ contract FeeOnTransferTokenTest is BaseInterchainToken, Distributable, IERC20Min
         bytes calldata /*metadata*/
     ) internal override {
         if (!tokenManagerRequiresApproval_) return;
-        address tokenManagerAddress = address(tokenManager_);
+        address tokenManagerAddress = tokenManager_;
         uint256 allowance_ = allowance[sender][tokenManagerAddress];
         if (allowance_ != UINT256_MAX) {
             if (allowance_ > UINT256_MAX - amount) {
@@ -58,7 +57,7 @@ contract FeeOnTransferTokenTest is BaseInterchainToken, Distributable, IERC20Min
         _burn(account, amount);
     }
 
-    function setTokenManager(ITokenManager tokenManagerAddress) external {
+    function setTokenManager(address tokenManagerAddress) external {
         tokenManager_ = tokenManagerAddress;
     }
 

--- a/contracts/test/FeeOnTransferTokenTest.sol
+++ b/contracts/test/FeeOnTransferTokenTest.sol
@@ -2,12 +2,12 @@
 
 pragma solidity ^0.8.0;
 
-import { InterchainTokenBase } from '../interchain-token/InterchainTokenBase.sol';
+import { BaseInterchainToken } from '../interchain-token/BaseInterchainToken.sol';
 import { Distributable } from '../utils/Distributable.sol';
 import { ITokenManager } from '../interfaces/ITokenManager.sol';
 import { IERC20MintableBurnable } from '../interfaces/IERC20MintableBurnable.sol';
 
-contract FeeOnTransferTokenTest is InterchainTokenBase, Distributable, IERC20MintableBurnable {
+contract FeeOnTransferTokenTest is BaseInterchainToken, Distributable, IERC20MintableBurnable {
     ITokenManager public tokenManager_;
     bool internal tokenManagerRequiresApproval_ = true;
 

--- a/contracts/test/InterchainTokenTest.sol
+++ b/contracts/test/InterchainTokenTest.sol
@@ -4,11 +4,10 @@ pragma solidity ^0.8.0;
 
 import { BaseInterchainToken } from '../interchain-token/BaseInterchainToken.sol';
 import { Distributable } from '../utils/Distributable.sol';
-import { ITokenManager } from '../interfaces/ITokenManager.sol';
 import { IERC20MintableBurnable } from '../interfaces/IERC20MintableBurnable.sol';
 
 contract InterchainTokenTest is BaseInterchainToken, Distributable, IERC20MintableBurnable {
-    ITokenManager public tokenManager_;
+    address public tokenManager_;
     bool internal tokenManagerRequiresApproval_ = true;
     string public name;
     string public symbol;
@@ -19,10 +18,10 @@ contract InterchainTokenTest is BaseInterchainToken, Distributable, IERC20Mintab
         symbol = symbol_;
         decimals = decimals_;
         _addDistributor(msg.sender);
-        tokenManager_ = ITokenManager(tokenManagerAddress);
+        tokenManager_ = tokenManagerAddress;
     }
 
-    function tokenManager() public view override returns (ITokenManager) {
+    function tokenManager() public view override returns (address) {
         return tokenManager_;
     }
 
@@ -34,7 +33,7 @@ contract InterchainTokenTest is BaseInterchainToken, Distributable, IERC20Mintab
         bytes calldata /*metadata*/
     ) internal override {
         if (!tokenManagerRequiresApproval_) return;
-        address tokenManagerAddress = address(tokenManager_);
+        address tokenManagerAddress = tokenManager_;
         uint256 allowance_ = allowance[sender][tokenManagerAddress];
         if (allowance_ != UINT256_MAX) {
             if (allowance_ > UINT256_MAX - amount) {
@@ -57,7 +56,7 @@ contract InterchainTokenTest is BaseInterchainToken, Distributable, IERC20Mintab
         _burn(account, amount);
     }
 
-    function setTokenManager(ITokenManager tokenManagerAddress) external {
+    function setTokenManager(address tokenManagerAddress) external {
         tokenManager_ = tokenManagerAddress;
     }
 }

--- a/contracts/test/InterchainTokenTest.sol
+++ b/contracts/test/InterchainTokenTest.sol
@@ -2,12 +2,12 @@
 
 pragma solidity ^0.8.0;
 
-import { InterchainTokenBase } from '../interchain-token/InterchainTokenBase.sol';
+import { BaseInterchainToken } from '../interchain-token/BaseInterchainToken.sol';
 import { Distributable } from '../utils/Distributable.sol';
 import { ITokenManager } from '../interfaces/ITokenManager.sol';
 import { IERC20MintableBurnable } from '../interfaces/IERC20MintableBurnable.sol';
 
-contract InterchainTokenTest is InterchainTokenBase, Distributable, IERC20MintableBurnable {
+contract InterchainTokenTest is BaseInterchainToken, Distributable, IERC20MintableBurnable {
     ITokenManager public tokenManager_;
     bool internal tokenManagerRequiresApproval_ = true;
     string public name;

--- a/contracts/test/InvalidInterchainToken.sol
+++ b/contracts/test/InvalidInterchainToken.sol
@@ -31,7 +31,7 @@ contract InvalidInterchainToken is IERC20MintableBurnable, BaseInterchainToken, 
 
     /**
      * @notice Returns the token manager for this token
-     * @return ITokenManager The token manager contract
+     * @return address The token manager contract
      */
     function tokenManager() public view override returns (address) {
         return tokenManager_;

--- a/contracts/test/InvalidInterchainToken.sol
+++ b/contracts/test/InvalidInterchainToken.sol
@@ -33,8 +33,8 @@ contract InvalidInterchainToken is IERC20MintableBurnable, BaseInterchainToken, 
      * @notice Returns the token manager for this token
      * @return ITokenManager The token manager contract
      */
-    function tokenManager() public view override returns (ITokenManager) {
-        return ITokenManager(tokenManager_);
+    function tokenManager() public view override returns (address) {
+        return tokenManager_;
     }
 
     /**

--- a/contracts/test/InvalidInterchainToken.sol
+++ b/contracts/test/InvalidInterchainToken.sol
@@ -6,7 +6,6 @@ import { AddressBytes } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/
 import { Implementation } from '@axelar-network/axelar-gmp-sdk-solidity/contracts/upgradable/Implementation.sol';
 
 import { IERC20MintableBurnable } from '../interfaces/IERC20MintableBurnable.sol';
-import { ITokenManager } from '../interfaces/ITokenManager.sol';
 
 import { BaseInterchainToken } from '../interchain-token/BaseInterchainToken.sol';
 import { ERC20Permit } from '../interchain-token/ERC20Permit.sol';

--- a/contracts/test/InvalidInterchainToken.sol
+++ b/contracts/test/InvalidInterchainToken.sol
@@ -8,11 +8,11 @@ import { Implementation } from '@axelar-network/axelar-gmp-sdk-solidity/contract
 import { IERC20MintableBurnable } from '../interfaces/IERC20MintableBurnable.sol';
 import { ITokenManager } from '../interfaces/ITokenManager.sol';
 
-import { InterchainTokenBase } from '../interchain-token/InterchainTokenBase.sol';
+import { BaseInterchainToken } from '../interchain-token/BaseInterchainToken.sol';
 import { ERC20Permit } from '../interchain-token/ERC20Permit.sol';
 import { Distributable } from '../utils/Distributable.sol';
 
-contract InvalidInterchainToken is IERC20MintableBurnable, InterchainTokenBase, ERC20Permit, Implementation, Distributable {
+contract InvalidInterchainToken is IERC20MintableBurnable, BaseInterchainToken, ERC20Permit, Implementation, Distributable {
     using AddressBytes for bytes;
 
     string public name;

--- a/docs/index.md
+++ b/docs/index.md
@@ -381,109 +381,6 @@ to spend tokens on their behalf via a signed message._
 | r | bytes32 | Half of the ECDSA signature pair |
 | s | bytes32 | Half of the ECDSA signature pair |
 
-## InterchainToken
-
-This contract implements a interchain token which extends InterchainToken functionality.
-This contract also inherits Distributable and Implementation logic.
-
-### name
-
-```solidity
-string name
-```
-
-Getter for the name of the token
-
-### symbol
-
-```solidity
-string symbol
-```
-
-Getter for the symbol of the token
-
-### decimals
-
-```solidity
-uint8 decimals
-```
-
-Getter for the decimals of the token
-
-### tokenManager_
-
-```solidity
-address tokenManager_
-```
-
-### contractId
-
-```solidity
-function contractId() external pure returns (bytes32)
-```
-
-Getter for the contract id.
-
-### tokenManager
-
-```solidity
-function tokenManager() public view returns (address)
-```
-
-Returns the token manager for this token
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | address | address The token manager contract |
-
-### setup
-
-```solidity
-function setup(bytes params) external
-```
-
-Setup function to initialize contract parameters
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| params | bytes | The setup parameters in bytes The setup params include tokenManager, distributor, tokenName, symbol, decimals, mintAmount and mintTo |
-
-### mint
-
-```solidity
-function mint(address account, uint256 amount) external
-```
-
-Function to mint new tokens
-Can only be called by the distributor address.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| account | address | The address that will receive the minted tokens |
-| amount | uint256 | The amount of tokens to mint |
-
-### burn
-
-```solidity
-function burn(address account, uint256 amount) external
-```
-
-Function to burn tokens
-Can only be called by the distributor address.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| account | address | The address that will have its tokens burnt |
-| amount | uint256 | The amount of tokens to burn |
-
 ## IDistributable
 
 ### transferDistributorship
@@ -580,34 +477,6 @@ _Can only be called by the distributor address._
 | from | address | The address that will have its tokens burnt |
 | amount | uint256 | The amount of tokens to burn |
 
-## IERC20Named
-
-_Interface of the ERC20 standard as defined in the EIP._
-
-### name
-
-```solidity
-function name() external view returns (string)
-```
-
-Getter for the name of the token
-
-### symbol
-
-```solidity
-function symbol() external view returns (string)
-```
-
-Getter for the symbol of the token
-
-### decimals
-
-```solidity
-function decimals() external view returns (uint8)
-```
-
-Getter for the decimals of the token
-
 ## IFlowLimit
 
 ### FlowLimitExceeded
@@ -663,36 +532,6 @@ Returns the current flow in amount
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | flowInAmount_ | uint256 | The current flow in amount |
-
-## IInterchainToken
-
-### TokenManagerAddressZero
-
-```solidity
-error TokenManagerAddressZero()
-```
-
-### TokenNameEmpty
-
-```solidity
-error TokenNameEmpty()
-```
-
-### tokenManager
-
-```solidity
-function tokenManager() external view returns (address tokenManager_)
-```
-
-Getter for the tokenManager used for this token.
-
-_Needs to be overwitten._
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManager_ | address | the TokenManager called to facilitate cross chain transfers. |
 
 ## IInterchainTokenStandard
 
@@ -1212,6 +1051,167 @@ enum Roles {
   FLOW_LIMITER
 }
 ```
+
+## InterchainToken
+
+This contract implements a interchain token which extends InterchainToken functionality.
+This contract also inherits Distributable and Implementation logic.
+
+### name
+
+```solidity
+string name
+```
+
+Getter for the name of the token
+
+### symbol
+
+```solidity
+string symbol
+```
+
+Getter for the symbol of the token
+
+### decimals
+
+```solidity
+uint8 decimals
+```
+
+Getter for the decimals of the token
+
+### tokenManager_
+
+```solidity
+address tokenManager_
+```
+
+### contractId
+
+```solidity
+function contractId() external pure returns (bytes32)
+```
+
+Getter for the contract id.
+
+### tokenManager
+
+```solidity
+function tokenManager() public view returns (address)
+```
+
+Returns the token manager for this token
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | address | address The token manager contract |
+
+### setup
+
+```solidity
+function setup(bytes params) external
+```
+
+Setup function to initialize contract parameters
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| params | bytes | The setup parameters in bytes The setup params include tokenManager, distributor, tokenName, symbol, decimals, mintAmount and mintTo |
+
+### mint
+
+```solidity
+function mint(address account, uint256 amount) external
+```
+
+Function to mint new tokens
+Can only be called by the distributor address.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| account | address | The address that will receive the minted tokens |
+| amount | uint256 | The amount of tokens to mint |
+
+### burn
+
+```solidity
+function burn(address account, uint256 amount) external
+```
+
+Function to burn tokens
+Can only be called by the distributor address.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| account | address | The address that will have its tokens burnt |
+| amount | uint256 | The amount of tokens to burn |
+
+## IERC20Named
+
+_Interface of the ERC20 standard as defined in the EIP._
+
+### name
+
+```solidity
+function name() external view returns (string)
+```
+
+Getter for the name of the token
+
+### symbol
+
+```solidity
+function symbol() external view returns (string)
+```
+
+Getter for the symbol of the token
+
+### decimals
+
+```solidity
+function decimals() external view returns (uint8)
+```
+
+Getter for the decimals of the token
+
+## IInterchainToken
+
+### TokenManagerAddressZero
+
+```solidity
+error TokenManagerAddressZero()
+```
+
+### TokenNameEmpty
+
+```solidity
+error TokenNameEmpty()
+```
+
+### tokenManager
+
+```solidity
+function tokenManager() external view returns (address tokenManager_)
+```
+
+Getter for the tokenManager used for this token.
+
+_Needs to be overwitten._
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManager_ | address | the TokenManager called to facilitate cross chain transfers. |
 
 ## InterchainTokenFactory
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1093 +1,6 @@
 # Solidity API
 
-## IMockAxelarGateway
-
-This interface is used for testing with an AxelarGateway that will arbitrarily approve calls.
-
-### NotSelf
-
-```solidity
-error NotSelf()
-```
-
-### NotProxy
-
-```solidity
-error NotProxy()
-```
-
-### InvalidCodeHash
-
-```solidity
-error InvalidCodeHash()
-```
-
-### SetupFailed
-
-```solidity
-error SetupFailed()
-```
-
-### InvalidAuthModule
-
-```solidity
-error InvalidAuthModule()
-```
-
-### InvalidTokenDeployer
-
-```solidity
-error InvalidTokenDeployer()
-```
-
-### InvalidAmount
-
-```solidity
-error InvalidAmount()
-```
-
-### InvalidChainId
-
-```solidity
-error InvalidChainId()
-```
-
-### InvalidCommands
-
-```solidity
-error InvalidCommands()
-```
-
-### TokenDoesNotExist
-
-```solidity
-error TokenDoesNotExist(string symbol)
-```
-
-### TokenAlreadyExists
-
-```solidity
-error TokenAlreadyExists(string symbol)
-```
-
-### TokenDeployFailed
-
-```solidity
-error TokenDeployFailed(string symbol)
-```
-
-### TokenContractDoesNotExist
-
-```solidity
-error TokenContractDoesNotExist(address token)
-```
-
-### BurnFailed
-
-```solidity
-error BurnFailed(string symbol)
-```
-
-### MintFailed
-
-```solidity
-error MintFailed(string symbol)
-```
-
-### InvalidSetMintLimitsParams
-
-```solidity
-error InvalidSetMintLimitsParams()
-```
-
-### ExceedMintLimit
-
-```solidity
-error ExceedMintLimit(string symbol)
-```
-
-### TokenSent
-
-```solidity
-event TokenSent(address sender, string destinationChain, string destinationAddress, string symbol, uint256 amount)
-```
-
-### ContractCall
-
-```solidity
-event ContractCall(address sender, string destinationChain, string destinationContractAddress, bytes32 payloadHash, bytes payload)
-```
-
-### ContractCallWithToken
-
-```solidity
-event ContractCallWithToken(address sender, string destinationChain, string destinationContractAddress, bytes32 payloadHash, bytes payload, string symbol, uint256 amount)
-```
-
-### Executed
-
-```solidity
-event Executed(bytes32 commandId)
-```
-
-### TokenDeployed
-
-```solidity
-event TokenDeployed(string symbol, address tokenAddresses)
-```
-
-### ContractCallApproved
-
-```solidity
-event ContractCallApproved(bytes32 commandId, string sourceChain, string sourceAddress, address contractAddress, bytes32 payloadHash, bytes32 sourceTxHash, uint256 sourceEventIndex)
-```
-
-### ContractCallApprovedWithMint
-
-```solidity
-event ContractCallApprovedWithMint(bytes32 commandId, string sourceChain, string sourceAddress, address contractAddress, bytes32 payloadHash, string symbol, uint256 amount, bytes32 sourceTxHash, uint256 sourceEventIndex)
-```
-
-### TokenMintLimitUpdated
-
-```solidity
-event TokenMintLimitUpdated(string symbol, uint256 limit)
-```
-
-### OperatorshipTransferred
-
-```solidity
-event OperatorshipTransferred(bytes newOperatorsData)
-```
-
-### Upgraded
-
-```solidity
-event Upgraded(address implementation)
-```
-
-### callContract
-
-```solidity
-function callContract(string destinationChain, string contractAddress, bytes payload) external
-```
-
-### isContractCallApproved
-
-```solidity
-function isContractCallApproved(bytes32 commandId, string sourceChain, string sourceAddress, address contractAddress, bytes32 payloadHash) external view returns (bool)
-```
-
-### validateContractCall
-
-```solidity
-function validateContractCall(bytes32 commandId, string sourceChain, string sourceAddress, bytes32 payloadHash) external returns (bool)
-```
-
-### setTokenAddress
-
-```solidity
-function setTokenAddress(string symbol, address tokenAddress) external
-```
-
-### approveContractCall
-
-```solidity
-function approveContractCall(bytes params, bytes32 commandId) external
-```
-
-### isCommandExecuted
-
-```solidity
-function isCommandExecuted(bytes32 commandId) external view returns (bool)
-```
-
-### tokenAddresses
-
-```solidity
-function tokenAddresses(string symbol) external view returns (address tokenAddress)
-```
-
-## AddressTracker
-
-### constructor
-
-```solidity
-constructor(address owner_, string chainName_, string[] trustedChainNames, string[] trustedAddresses) public
-```
-
-### setTrustedAddress
-
-```solidity
-function setTrustedAddress(string chain, string address_) external
-```
-
-_Sets the trusted address for the specified chain_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| chain | string | Chain name to be trusted |
-| address_ | string | Trusted address to be added for the chain |
-
-### removeTrustedAddress
-
-```solidity
-function removeTrustedAddress(string chain) external
-```
-
-_Remove the trusted address of the chain._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| chain | string | Chain name that should be made untrusted |
-
-## InterchainTokenExecutable
-
-### NotService
-
-```solidity
-error NotService(address caller)
-```
-
-### interchainTokenService
-
-```solidity
-address interchainTokenService
-```
-
-### EXECUTE_SUCCESS
-
-```solidity
-bytes32 EXECUTE_SUCCESS
-```
-
-### constructor
-
-```solidity
-constructor(address interchainTokenService_) internal
-```
-
-### onlyService
-
-```solidity
-modifier onlyService()
-```
-
-### executeWithInterchainToken
-
-```solidity
-function executeWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) external virtual returns (bytes32)
-```
-
-This will be called after the tokens arrive to this contract
-
-_Executable should revert unless the msg.sender is the InterchainTokenService_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sourceChain | string | the name of the source chain |
-| sourceAddress | bytes | the address that sent the contract call |
-| data | bytes | the data to be processed |
-| tokenId | bytes32 | the tokenId of the token manager managing the token. |
-| token | address | the address of the token. |
-| amount | uint256 | the amount of token that was sent |
-
-### _executeWithInterchainToken
-
-```solidity
-function _executeWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) internal virtual
-```
-
-## InterchainTokenExpressExecutable
-
-### EXPRESS_EXECUTE_SUCCESS
-
-```solidity
-bytes32 EXPRESS_EXECUTE_SUCCESS
-```
-
-### constructor
-
-```solidity
-constructor(address interchainTokenService_) internal
-```
-
-### expressExecuteWithInterchainToken
-
-```solidity
-function expressExecuteWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) external virtual returns (bytes32)
-```
-
-This will be called after the tokens arrive to this contract
-
-_Executable should revert unless the msg.sender is the InterchainTokenService_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sourceChain | string | the name of the source chain |
-| sourceAddress | bytes | the address that sent the contract call |
-| data | bytes | the data to be processed |
-| tokenId | bytes32 | the token id of the token manager managing the token. |
-| token | address | the address of the token. |
-| amount | uint256 | the amount of token that was sent |
-
-## InterchainTokenService
-
-This contract is responsible for facilitating cross chain token transfers.
-It (mostly) does not handle tokens, but is responsible for the messaging that needs to occur for cross chain transfers to happen.
-
-_The only storage used here is for ExpressCalls_
-
-### gateway
-
-```solidity
-contract IAxelarGateway gateway
-```
-
-### gasService
-
-```solidity
-contract IAxelarGasService gasService
-```
-
-### chainNameHash
-
-```solidity
-bytes32 chainNameHash
-```
-
-### interchainTokenDeployer
-
-```solidity
-address interchainTokenDeployer
-```
-
-Returns the address of the interchain token deployer contract.
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-
-### tokenManagerDeployer
-
-```solidity
-address tokenManagerDeployer
-```
-
-Returns the address of the token manager deployer contract.
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-
-### implementationLockUnlock
-
-```solidity
-address implementationLockUnlock
-```
-
-_Token manager implementation addresses_
-
-### implementationLockUnlockFee
-
-```solidity
-address implementationLockUnlockFee
-```
-
-### implementationMintBurn
-
-```solidity
-address implementationMintBurn
-```
-
-### implementationMintBurnFrom
-
-```solidity
-address implementationMintBurnFrom
-```
-
-### interchainAddressTracker
-
-```solidity
-contract IInterchainAddressTracker interchainAddressTracker
-```
-
-Returns the address of the interchain router contract.
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-
-### PREFIX_TOKEN_ID
-
-```solidity
-bytes32 PREFIX_TOKEN_ID
-```
-
-### PREFIX_INTERCHAIN_TOKEN_SALT
-
-```solidity
-bytes32 PREFIX_INTERCHAIN_TOKEN_SALT
-```
-
-### constructor
-
-```solidity
-constructor(address tokenManagerDeployer_, address interchainTokenDeployer_, address gateway_, address gasService_, address interchainAddressTracker_, address[] tokenManagerImplementations) public
-```
-
-_All of the variables passed here are stored as immutable variables._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManagerDeployer_ | address | the address of the TokenManagerDeployer. |
-| interchainTokenDeployer_ | address | the address of the InterchainTokenDeployer. |
-| gateway_ | address | the address of the AxelarGateway. |
-| gasService_ | address | the address of the AxelarGasService. |
-| interchainAddressTracker_ | address | the address of the InterchainAddressTracker. |
-| tokenManagerImplementations | address[] | this needs to have implementations in the order: Mint-burn, Mint-burn from, Lock-unlock, and Lock-unlock with fee. |
-
-### onlyRemoteService
-
-```solidity
-modifier onlyRemoteService(string sourceChain, string sourceAddress)
-```
-
-This modifier is used to ensure that only a remote InterchainTokenService can _execute this one.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sourceChain | string | the source of the contract call. |
-| sourceAddress | string | the address that the call came from. |
-
-### onlyTokenManager
-
-```solidity
-modifier onlyTokenManager(bytes32 tokenId)
-```
-
-This modifier is used to ensure certain functions can only be called by TokenManagers.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the `tokenId` of the TokenManager trying to perform the call. |
-
-### contractId
-
-```solidity
-function contractId() external pure returns (bytes32)
-```
-
-Getter for the contract id.
-
-### tokenManagerAddress
-
-```solidity
-function tokenManagerAddress(bytes32 tokenId) public view returns (address tokenManagerAddress_)
-```
-
-Calculates the address of a TokenManager from a specific tokenId. The TokenManager does not need to exist already.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the tokenId. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManagerAddress_ | address | deployment address of the TokenManager. |
-
-### validTokenManagerAddress
-
-```solidity
-function validTokenManagerAddress(bytes32 tokenId) public view returns (address tokenManagerAddress_)
-```
-
-Returns the address of a TokenManager from a specific tokenId. The TokenManager needs to exist already.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the tokenId. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManagerAddress_ | address | deployment address of the TokenManager. |
-
-### tokenAddress
-
-```solidity
-function tokenAddress(bytes32 tokenId) external view returns (address tokenAddress_)
-```
-
-Returns the address of the token that an existing tokenManager points to.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the tokenId. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenAddress_ | address | the address of the token. |
-
-### interchainTokenAddress
-
-```solidity
-function interchainTokenAddress(bytes32 tokenId) public view returns (address tokenAddress_)
-```
-
-Returns the address of the interchain token that would be deployed with a given tokenId.
-The token does not need to exist.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the tokenId. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenAddress_ | address | the address of the interchain token. |
-
-### interchainTokenId
-
-```solidity
-function interchainTokenId(address sender, bytes32 salt) public pure returns (bytes32 tokenId)
-```
-
-Calculates the tokenId that would correspond to a link for a given deployer with a specified salt.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sender | address | the address of the TokenManager deployer. |
-| salt | bytes32 | the salt that the deployer uses for the deployment. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the tokenId that the custom TokenManager would get (or has gotten). |
-
-### tokenManagerImplementation
-
-```solidity
-function tokenManagerImplementation(uint256 tokenManagerType) external view returns (address)
-```
-
-Getter function for TokenManager implementations. This will mainly be called by TokenManagerProxies
-to figure out their implementations
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManagerType | uint256 | the type of the TokenManager. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | address | tokenManagerAddress the address of the TokenManagerImplementation. |
-
-### flowLimit
-
-```solidity
-function flowLimit(bytes32 tokenId) external view returns (uint256 flowLimit_)
-```
-
-Getter function for the flow limit of an existing token manager with a give token ID.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the token ID of the TokenManager. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowLimit_ | uint256 | the flow limit. |
-
-### flowOutAmount
-
-```solidity
-function flowOutAmount(bytes32 tokenId) external view returns (uint256 flowOutAmount_)
-```
-
-Getter function for the flow out amount of an existing token manager with a give token ID.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the token ID of the TokenManager. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowOutAmount_ | uint256 | the flow out amount. |
-
-### flowInAmount
-
-```solidity
-function flowInAmount(bytes32 tokenId) external view returns (uint256 flowInAmount_)
-```
-
-Getter function for the flow in amount of an existing token manager with a give token ID.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the token ID of the TokenManager. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowInAmount_ | uint256 | the flow in amount. |
-
-### deployTokenManager
-
-```solidity
-function deployTokenManager(bytes32 salt, string destinationChain, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params, uint256 gasValue) external payable returns (bytes32 tokenId)
-```
-
-Used to deploy remote custom TokenManagers.
-
-_`gasValue` exists because this function can be part of a multicall involving multiple functions
-that could make remote contract calls._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| salt | bytes32 | the salt to be used. |
-| destinationChain | string | the name of the chain to deploy the TokenManager and interchain token to. |
-| tokenManagerType | enum ITokenManagerType.TokenManagerType | the type of TokenManager to be deployed. |
-| params | bytes | the params that will be used to initialize the TokenManager. |
-| gasValue | uint256 | the amount of native tokens to be used to pay for gas for the remote deployment. At least the amount specified needs to be passed to the call |
-
-### deployInterchainToken
-
-```solidity
-function deployInterchainToken(bytes32 salt, string destinationChain, string name, string symbol, uint8 decimals, bytes distributor, bytes operator, uint256 gasValue) external payable
-```
-
-Used to deploy a interchain token alongside a TokenManager in another chain. If the `distributor` is empty
-bytes then a mint/burn TokenManager is used. Otherwise a lock/unlock TokenManager is used.
-
-_`gasValue` exists because this function can be part of a multicall involving multiple functions that could make remote contract calls._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| salt | bytes32 | the salt to be used. |
-| destinationChain | string | the name of the destination chain to deploy to. |
-| name | string | the name of the token to be deployed. |
-| symbol | string | the symbol of the token to be deployed. |
-| decimals | uint8 | the decimals of the token to be deployed. |
-| distributor | bytes | the address that will be able to mint and burn the deployed token. |
-| operator | bytes |  |
-| gasValue | uint256 | the amount of native tokens to be used to pay for gas for the remote deployment. At least the amount specified needs to be passed to the call |
-
-### contractCallValue
-
-```solidity
-function contractCallValue(string sourceChain, string sourceAddress, bytes payload) public view virtual returns (address, uint256)
-```
-
-_Returns the value (token address and amount) associated with a contract call_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sourceChain | string | The source blockchain. |
-| sourceAddress | string | The source address. |
-| payload | bytes | The payload data. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | address |  |
-| [1] | uint256 |  |
-
-### expressExecute
-
-```solidity
-function expressExecute(bytes32 commandId, string sourceChain, string sourceAddress, bytes payload) external payable
-```
-
-Express executes a contract call.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| commandId | bytes32 | The commandId for the contractCall. |
-| sourceChain | string | The source chain. |
-| sourceAddress | string | The source address. |
-| payload | bytes | The payload data. |
-
-### _expressExecute
-
-```solidity
-function _expressExecute(string sourceChain, bytes payload) internal
-```
-
-Uses the caller's tokens to fullfill a sendCall ahead of time. Use this only if you have detected an outgoing
-interchainTransfer that matches the parameters passed here.
-
-_This is not to be used with fee on transfer tokens as it will incur losses for the express caller._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sourceChain | string | the name of the chain where the interchainTransfer originated from. |
-| payload | bytes | the payload of the receive token |
-
-### interchainTransfer
-
-```solidity
-function interchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
-```
-
-Transfer a token interchain.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the tokenId for the token link. |
-| destinationChain | string | the name of the chain to send the token to. |
-| destinationAddress | bytes | the recipient of the interchain transfer. |
-| amount | uint256 | the amount of token to give. |
-| metadata | bytes | the data to be passed to the destination. If provided with a bytes4(0) prefix, it'll execute the destination contract. |
-
-### callContractWithInterchainToken
-
-```solidity
-function callContractWithInterchainToken(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, bytes data) external payable
-```
-
-### transmitInterchainTransfer
-
-```solidity
-function transmitInterchainTransfer(bytes32 tokenId, address sourceAddress, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
-```
-
-Transmit an interchain transfer for the given tokenId. Only callable by a token manager.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the tokenId of the TokenManager (which must be the msg.sender). |
-| sourceAddress | address | the address where the token is coming from, which will also be used for reimbursement of gas. |
-| destinationChain | string | the name of the chain to send tokens to. |
-| destinationAddress | bytes | the destinationAddress for the interchainTransfer. |
-| amount | uint256 | the amount of token to give. |
-| metadata | bytes | the data to be passed to the destination. |
-
-### setFlowLimits
-
-```solidity
-function setFlowLimits(bytes32[] tokenIds, uint256[] flowLimits) external
-```
-
-Used to set a flow limit for a token manager that has the service as its operator.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenIds | bytes32[] | an array of the token Ids of the tokenManagers to set the flow limit of. |
-| flowLimits | uint256[] | the flowLimits to set |
-
-### setPauseStatus
-
-```solidity
-function setPauseStatus(bool paused) external
-```
-
-Allows the owner to pause/unpause the token service.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| paused | bool | whether to pause or unpause. |
-
-### _setup
-
-```solidity
-function _setup(bytes params) internal
-```
-
-### _sanitizeTokenManagerImplementation
-
-```solidity
-function _sanitizeTokenManagerImplementation(address[] tokenManagerImplementations, enum ITokenManagerType.TokenManagerType tokenManagerType) internal pure returns (address implementation_)
-```
-
-### execute
-
-```solidity
-function execute(bytes32 commandId, string sourceChain, string sourceAddress, bytes payload) external
-```
-
-Executes operations based on the payload and messageType.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| commandId | bytes32 |  |
-| sourceChain | string | The chain where the transaction originates from |
-| sourceAddress | string | The address of the remote ITS where the transaction originates from |
-| payload | bytes | The encoded data payload for the transaction |
-
-### contractCallWithTokenValue
-
-```solidity
-function contractCallWithTokenValue(string, string, bytes, string, uint256) public view virtual returns (address, uint256)
-```
-
-### expressExecuteWithToken
-
-```solidity
-function expressExecuteWithToken(bytes32, string, string, bytes, string, uint256) external payable
-```
-
-### executeWithToken
-
-```solidity
-function executeWithToken(bytes32, string, string, bytes, string, uint256) external pure
-```
-
-### _processInterchainTransferPayload
-
-```solidity
-function _processInterchainTransferPayload(address expressExecutor, string sourceChain, bytes payload, uint256 messageType) internal
-```
-
-Processes the payload data for a send token call
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expressExecutor | address |  |
-| sourceChain | string | The chain where the transaction originates from |
-| payload | bytes | The encoded data payload to be processed |
-| messageType | uint256 |  |
-
-### _processDeployTokenManagerPayload
-
-```solidity
-function _processDeployTokenManagerPayload(bytes payload) internal
-```
-
-Processes a deploy token manager payload.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| payload | bytes | The encoded data payload to be processed |
-
-### _processDeployInterchainTokenPayload
-
-```solidity
-function _processDeployInterchainTokenPayload(bytes payload) internal
-```
-
-Process a deploy interchain token and manager payload.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| payload | bytes | The encoded data payload to be processed |
-
-### _callContract
-
-```solidity
-function _callContract(string destinationChain, bytes payload, uint256 gasValue) internal
-```
-
-Calls a contract on a specific destination chain with the given payload
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| destinationChain | string | The target chain where the contract will be called |
-| payload | bytes | The data payload for the transaction |
-| gasValue | uint256 | The amount of gas to be paid for the transaction |
-
-### _validateToken
-
-```solidity
-function _validateToken(address tokenAddress_) internal view returns (string name, string symbol, uint8 decimals)
-```
-
-### _deployRemoteTokenManager
-
-```solidity
-function _deployRemoteTokenManager(bytes32 tokenId, string destinationChain, uint256 gasValue, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params) internal
-```
-
-Deploys a token manager on a destination chain.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The ID of the token |
-| destinationChain | string | The chain where the token manager will be deployed |
-| gasValue | uint256 | The amount of gas to be paid for the transaction |
-| tokenManagerType | enum ITokenManagerType.TokenManagerType | The type of token manager to be deployed |
-| params | bytes | Additional parameters for the token manager deployment |
-
-### _deployRemoteInterchainToken
-
-```solidity
-function _deployRemoteInterchainToken(bytes32 tokenId, string name, string symbol, uint8 decimals, bytes distributor, bytes operator, string destinationChain, uint256 gasValue) internal
-```
-
-Deploys a interchain token on a destination chain.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The ID of the token |
-| name | string | The name of the token |
-| symbol | string | The symbol of the token |
-| decimals | uint8 | The number of decimals of the token |
-| distributor | bytes | The distributor address for the token |
-| operator | bytes |  |
-| destinationChain | string | The destination chain where the token will be deployed |
-| gasValue | uint256 | The amount of gas to be paid for the transaction |
-
-### _deployTokenManager
-
-```solidity
-function _deployTokenManager(bytes32 tokenId, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params) internal
-```
-
-Deploys a token manager
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The ID of the token |
-| tokenManagerType | enum ITokenManagerType.TokenManagerType | The type of the token manager to be deployed |
-| params | bytes | Additional parameters for the token manager deployment |
-
-### _getInterchainTokenSalt
-
-```solidity
-function _getInterchainTokenSalt(bytes32 tokenId) internal pure returns (bytes32 salt)
-```
-
-Compute the salt for a interchain token deployment.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The ID of the token |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| salt | bytes32 | The computed salt for the token deployment |
-
-### _deployInterchainToken
-
-```solidity
-function _deployInterchainToken(bytes32 tokenId, bytes distributorBytes, string name, string symbol, uint8 decimals) internal returns (address tokenAddress_)
-```
-
-Deploys a interchain token.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The ID of the token |
-| distributorBytes | bytes | The distributor address for the token |
-| name | string | The name of the token |
-| symbol | string | The symbol of the token |
-| decimals | uint8 | The number of decimals of the token |
-
-### _decodeMetadata
-
-```solidity
-function _decodeMetadata(bytes metadata) internal pure returns (uint32 version, bytes data)
-```
-
-### _transmitInterchainTransfer
-
-```solidity
-function _transmitInterchainTransfer(bytes32 tokenId, address sourceAddress, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) internal
-```
-
-Transmit a callContractWithInterchainToken for the given tokenId. Only callable by a token manager.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | the tokenId of the TokenManager (which must be the msg.sender). |
-| sourceAddress | address | the address where the token is coming from, which will also be used for reimburment of gas. |
-| destinationChain | string | the name of the chain to send tokens to. |
-| destinationAddress | bytes | the destinationAddress for the interchainTransfer. |
-| amount | uint256 | the amount of token to give. |
-| metadata | bytes | the data to be passed to the destination. |
-
-## InterchainToken
+## BaseInterchainToken
 
 The implementation ERC20 can be done in any way, however this example assumes that an _approve internal function exists
 that can be used to create approvals, and that `allowance` is a mapping.
@@ -1095,7 +8,7 @@ that can be used to create approvals, and that `allowance` is a mapping.
 ### tokenManager
 
 ```solidity
-function tokenManager() public view virtual returns (contract ITokenManager tokenManager_)
+function tokenManager() public view virtual returns (address tokenManager_)
 ```
 
 Getter for the tokenManager used for this token.
@@ -1106,7 +19,7 @@ _Needs to be overwritten._
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| tokenManager_ | contract ITokenManager | the TokenManager called to facilitate cross chain transfers. |
+| tokenManager_ | address | the TokenManager called to facilitate cross chain transfers. |
 
 ### interchainTransfer
 
@@ -1166,2410 +79,6 @@ A method to be overwritten that will be called before an interchain transfer. Yo
 | destinationAddress | bytes | the bytes representation of the address of the recipient. |
 | amount | uint256 | the amount of token to be transferred. |
 | metadata | bytes | either empty, to just facilitate a cross-chain transfer, or the data to be passed to a cross-chain contract call and transfer. |
-
-## IAddressTracker
-
-### setTrustedAddress
-
-```solidity
-function setTrustedAddress(string chain, string address_) external
-```
-
-_Sets the trusted address for the specified chain_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| chain | string | Chain name to be trusted |
-| address_ | string | Trusted address to be added for the chain |
-
-### removeTrustedAddress
-
-```solidity
-function removeTrustedAddress(string chain) external
-```
-
-_Remove the trusted address of the chain._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| chain | string | Chain name that should be made untrusted |
-
-## IDistributable
-
-### transferDistributorship
-
-```solidity
-function transferDistributorship(address distributor_) external
-```
-
-Change the distributor of the contract
-
-_Can only be called by the current distributor_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| distributor_ | address | The address of the new distributor |
-
-### proposeDistributorship
-
-```solidity
-function proposeDistributorship(address distributor_) external
-```
-
-Proposed a change of the distributor of the contract
-
-_Can only be called by the current distributor_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| distributor_ | address | The address of the new distributor |
-
-### acceptDistributorship
-
-```solidity
-function acceptDistributorship(address fromDistributor) external
-```
-
-Accept a change of the distributor of the contract
-
-_Can only be called by the proposed distributor_
-
-### isDistributor
-
-```solidity
-function isDistributor(address addr) external view returns (bool)
-```
-
-Query if an address is a distributor
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| addr | address | the address to query for |
-
-## IERC20BurnableFrom
-
-_Interface of the ERC20 standard as defined in the EIP._
-
-### burnFrom
-
-```solidity
-function burnFrom(address from, uint256 amount) external
-```
-
-Function to burn tokens
-Requires the caller to have allowance for `amount` on `from`
-
-_Can only be called by the distributor address._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| from | address | The address that will have its tokens burnt |
-| amount | uint256 | The amount of tokens to burn |
-
-## IERC20MintableBurnable
-
-_Interface of the ERC20 standard as defined in the EIP._
-
-### mint
-
-```solidity
-function mint(address to, uint256 amount) external
-```
-
-Function to mint new tokens
-
-_Can only be called by the distributor address._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| to | address | The address that will receive the minted tokens |
-| amount | uint256 | The amount of tokens to mint |
-
-### burn
-
-```solidity
-function burn(address from, uint256 amount) external
-```
-
-Function to burn tokens
-
-_Can only be called by the distributor address._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| from | address | The address that will have its tokens burnt |
-| amount | uint256 | The amount of tokens to burn |
-
-## IERC20Named
-
-_Interface of the ERC20 standard as defined in the EIP._
-
-### name
-
-```solidity
-function name() external view returns (string)
-```
-
-Getter for the name of the token
-
-### symbol
-
-```solidity
-function symbol() external view returns (string)
-```
-
-Getter for the symbol of the token
-
-### decimals
-
-```solidity
-function decimals() external view returns (uint8)
-```
-
-Getter for the decimals of the token
-
-## IFlowLimit
-
-### FlowLimitExceeded
-
-```solidity
-error FlowLimitExceeded(uint256 limit, uint256 flowAmount)
-```
-
-### FlowLimitSet
-
-```solidity
-event FlowLimitSet(bytes32 tokenId, address operator, uint256 flowLimit_)
-```
-
-### flowLimit
-
-```solidity
-function flowLimit() external view returns (uint256 flowLimit_)
-```
-
-Returns the current flow limit
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowLimit_ | uint256 | The current flow limit value |
-
-### flowOutAmount
-
-```solidity
-function flowOutAmount() external view returns (uint256 flowOutAmount_)
-```
-
-Returns the current flow out amount
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowOutAmount_ | uint256 | The current flow out amount |
-
-### flowInAmount
-
-```solidity
-function flowInAmount() external view returns (uint256 flowInAmount_)
-```
-
-Returns the current flow in amount
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowInAmount_ | uint256 | The current flow in amount |
-
-## IImplementation
-
-### NotProxy
-
-```solidity
-error NotProxy()
-```
-
-### setup
-
-```solidity
-function setup(bytes params) external
-```
-
-Called by the proxy to setup itself.
-
-_This should be hidden by the proxy._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| params | bytes | the data to be used for the initialization. |
-
-## IInterchainToken
-
-_Interface of the ERC20 standard as defined in the EIP._
-
-### tokenManager
-
-```solidity
-function tokenManager() external view returns (contract ITokenManager tokenManager_)
-```
-
-Getter for the tokenManager used for this token.
-
-_Needs to be overwitten._
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManager_ | contract ITokenManager | the TokenManager called to facilitate cross chain transfers. |
-
-### interchainTransfer
-
-```solidity
-function interchainTransfer(string destinationChain, bytes recipient, uint256 amount, bytes metadata) external payable
-```
-
-Implementation of the interchainTransfer method
-
-_We chose to either pass `metadata` as raw data on a remote contract call, or, if no data is passed, just do a transfer.
-A different implementation could have `metadata` that tells this function which function to use or that it is used for anything else as well._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| destinationChain | string | The destination chain identifier. |
-| recipient | bytes | The bytes representation of the address of the recipient. |
-| amount | uint256 | The amount of token to be transferred. |
-| metadata | bytes | Either empty, to just facilitate an interchain transfer, or the data can be passed for an interchain contract call with transfer as per semantics defined by the token service. |
-
-### interchainTransferFrom
-
-```solidity
-function interchainTransferFrom(address sender, string destinationChain, bytes recipient, uint256 amount, bytes metadata) external payable
-```
-
-Implementation of the interchainTransferFrom method
-
-_We chose to either pass `metadata` as raw data on a remote contract call, or, if no data is passed, just do a transfer.
-A different implementation could have `metadata` that tells this function which function to use or that it is used for anything else as well._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sender | address | the sender of the tokens. They need to have approved `msg.sender` before this is called. |
-| destinationChain | string | the string representation of the destination chain. |
-| recipient | bytes | the bytes representation of the address of the recipient. |
-| amount | uint256 | the amount of token to be transferred. |
-| metadata | bytes | either empty, to just facilitate a cross-chain transfer, or the data to be passed to a cross-chain contract call and transfer. |
-
-## IInterchainTokenDeployer
-
-This contract is used to deploy new instances of the InterchainTokenProxy contract.
-
-### AddressZero
-
-```solidity
-error AddressZero()
-```
-
-### TokenDeploymentFailed
-
-```solidity
-error TokenDeploymentFailed()
-```
-
-### implementationAddress
-
-```solidity
-function implementationAddress() external view returns (address)
-```
-
-Returns the interchain token implementation address
-
-### deployedAddress
-
-```solidity
-function deployedAddress(bytes32 salt) external view returns (address tokenAddress)
-```
-
-Returns the interchain token deployment address.
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenAddress | address | the token address. |
-
-### deployInterchainToken
-
-```solidity
-function deployInterchainToken(bytes32 salt, address tokenManager, address distributor, string name, string symbol, uint8 decimals) external payable returns (address tokenAddress)
-```
-
-Deploys a new instance of the InterchainTokenProxy contract
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| salt | bytes32 | The salt used by Create3Deployer |
-| tokenManager | address | Address of the token manager |
-| distributor | address | Address of the distributor |
-| name | string | Name of the token |
-| symbol | string | Symbol of the token |
-| decimals | uint8 | Decimals of the token |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenAddress | address | Address of the deployed token |
-
-## IInterchainTokenExecutable
-
-Implement this to accept calls from the InterchainTokenService.
-
-### executeWithInterchainToken
-
-```solidity
-function executeWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) external returns (bytes32)
-```
-
-This will be called after the tokens arrive to this contract
-
-_Executable should revert unless the msg.sender is the InterchainTokenService_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sourceChain | string | the name of the source chain |
-| sourceAddress | bytes | the address that sent the contract call |
-| data | bytes | the data to be processed |
-| tokenId | bytes32 | the tokenId of the token manager managing the token. |
-| token | address | the address of the token. |
-| amount | uint256 | the amount of token that was sent |
-
-## IInterchainTokenExpressExecutable
-
-Implement this to accept express calls from the InterchainTokenService.
-
-### expressExecuteWithInterchainToken
-
-```solidity
-function expressExecuteWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) external returns (bytes32)
-```
-
-This will be called after the tokens arrive to this contract
-
-_Executable should revert unless the msg.sender is the InterchainTokenService_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sourceChain | string | the name of the source chain |
-| sourceAddress | bytes | the address that sent the contract call |
-| data | bytes | the data to be processed |
-| tokenId | bytes32 | the token id of the token manager managing the token. |
-| token | address | the address of the token. |
-| amount | uint256 | the amount of token that was sent |
-
-## IInterchainTokenService
-
-### ZeroAddress
-
-```solidity
-error ZeroAddress()
-```
-
-### LengthMismatch
-
-```solidity
-error LengthMismatch()
-```
-
-### InvalidTokenManagerImplementationType
-
-```solidity
-error InvalidTokenManagerImplementationType(address implementation)
-```
-
-### NotRemoteService
-
-```solidity
-error NotRemoteService()
-```
-
-### TokenManagerDoesNotExist
-
-```solidity
-error TokenManagerDoesNotExist(bytes32 tokenId)
-```
-
-### NotTokenManager
-
-```solidity
-error NotTokenManager(address caller, address tokenManager)
-```
-
-### ExecuteWithInterchainTokenFailed
-
-```solidity
-error ExecuteWithInterchainTokenFailed(address contractAddress)
-```
-
-### ExpressExecuteWithInterchainTokenFailed
-
-```solidity
-error ExpressExecuteWithInterchainTokenFailed(address contractAddress)
-```
-
-### GatewayToken
-
-```solidity
-error GatewayToken()
-```
-
-### TokenManagerDeploymentFailed
-
-```solidity
-error TokenManagerDeploymentFailed(bytes error)
-```
-
-### InterchainTokenDeploymentFailed
-
-```solidity
-error InterchainTokenDeploymentFailed(bytes error)
-```
-
-### InvalidMessageType
-
-```solidity
-error InvalidMessageType(uint256 messageType)
-```
-
-### InvalidMetadataVersion
-
-```solidity
-error InvalidMetadataVersion(uint32 version)
-```
-
-### ExecuteWithTokenNotSupported
-
-```solidity
-error ExecuteWithTokenNotSupported()
-```
-
-### UntrustedChain
-
-```solidity
-error UntrustedChain(string chainName)
-```
-
-### InvalidExpressMessageType
-
-```solidity
-error InvalidExpressMessageType(uint256 messageType)
-```
-
-### InterchainTransfer
-
-```solidity
-event InterchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount)
-```
-
-### InterchainTransferWithData
-
-```solidity
-event InterchainTransferWithData(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, address sourceAddress, bytes data)
-```
-
-### InterchainTransferReceived
-
-```solidity
-event InterchainTransferReceived(bytes32 tokenId, string sourceChain, bytes sourceAddress, address destinationAddress, uint256 amount)
-```
-
-### InterchainTransferReceivedWithData
-
-```solidity
-event InterchainTransferReceivedWithData(bytes32 tokenId, string sourceChain, bytes sourceAddress, address destinationAddress, uint256 amount)
-```
-
-### TokenManagerDeploymentStarted
-
-```solidity
-event TokenManagerDeploymentStarted(bytes32 tokenId, string destinationChain, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params)
-```
-
-### InterchainTokenDeploymentStarted
-
-```solidity
-event InterchainTokenDeploymentStarted(bytes32 tokenId, string tokenName, string tokenSymbol, uint8 tokenDecimals, bytes distributor, bytes operator, string destinationChain)
-```
-
-### TokenManagerDeployed
-
-```solidity
-event TokenManagerDeployed(bytes32 tokenId, address tokenManager, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params)
-```
-
-### InterchainTokenDeployed
-
-```solidity
-event InterchainTokenDeployed(bytes32 tokenId, address tokenAddress, address distributor, string name, string symbol, uint8 decimals)
-```
-
-### InterchainTokenIdClaimed
-
-```solidity
-event InterchainTokenIdClaimed(bytes32 tokenId, address deployer, bytes32 salt)
-```
-
-### interchainAddressTracker
-
-```solidity
-function interchainAddressTracker() external view returns (contract IInterchainAddressTracker interchainAddressTracker_)
-```
-
-Returns the address of the interchain router contract.
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| interchainAddressTracker_ | contract IInterchainAddressTracker | The interchainAddressTracker. |
-
-### tokenManagerDeployer
-
-```solidity
-function tokenManagerDeployer() external view returns (address tokenManagerDeployerAddress)
-```
-
-Returns the address of the token manager deployer contract.
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManagerDeployerAddress | address | The address of the token manager deployer contract. |
-
-### interchainTokenDeployer
-
-```solidity
-function interchainTokenDeployer() external view returns (address interchainTokenDeployerAddress)
-```
-
-Returns the address of the interchain token deployer contract.
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| interchainTokenDeployerAddress | address | The address of the interchain token deployer contract. |
-
-### tokenManagerAddress
-
-```solidity
-function tokenManagerAddress(bytes32 tokenId) external view returns (address tokenManagerAddress_)
-```
-
-Returns the address of the token manager associated with the given tokenId.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The tokenId of the token manager. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManagerAddress_ | address | The address of the token manager. |
-
-### validTokenManagerAddress
-
-```solidity
-function validTokenManagerAddress(bytes32 tokenId) external view returns (address tokenManagerAddress_)
-```
-
-Returns the address of the valid token manager associated with the given tokenId.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The tokenId of the token manager. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManagerAddress_ | address | The address of the valid token manager. |
-
-### tokenAddress
-
-```solidity
-function tokenAddress(bytes32 tokenId) external view returns (address tokenAddress_)
-```
-
-Returns the address of the token associated with the given tokenId.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The tokenId of the token manager. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenAddress_ | address | The address of the token. |
-
-### interchainTokenAddress
-
-```solidity
-function interchainTokenAddress(bytes32 tokenId) external view returns (address tokenAddress_)
-```
-
-Returns the address of the interchain token associated with the given tokenId.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The tokenId of the interchain token. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenAddress_ | address | The address of the interchain token. |
-
-### interchainTokenId
-
-```solidity
-function interchainTokenId(address operator_, bytes32 salt) external view returns (bytes32 tokenId)
-```
-
-Returns the custom tokenId associated with the given operator and salt.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator_ | address | The operator address. |
-| salt | bytes32 | The salt used for token id calculation. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The custom tokenId associated with the operator and salt. |
-
-### deployTokenManager
-
-```solidity
-function deployTokenManager(bytes32 salt, string destinationChain, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params, uint256 gasValue) external payable returns (bytes32 tokenId)
-```
-
-Deploys a custom token manager contract on a remote chain.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| salt | bytes32 | The salt used for token manager deployment. |
-| destinationChain | string | The name of the destination chain. |
-| tokenManagerType | enum ITokenManagerType.TokenManagerType | The type of token manager. |
-| params | bytes | The deployment parameters. |
-| gasValue | uint256 | The gas value for deployment. |
-
-### deployInterchainToken
-
-```solidity
-function deployInterchainToken(bytes32 salt, string destinationChain, string name, string symbol, uint8 decimals, bytes distributor, bytes operator, uint256 gasValue) external payable
-```
-
-Deploys and registers a interchain token on a remote chain.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| salt | bytes32 | The salt used for token deployment. |
-| destinationChain | string | The name of the destination chain. Use '' for this chain. |
-| name | string | The name of the interchain tokens. |
-| symbol | string | The symbol of the interchain tokens. |
-| decimals | uint8 | The number of decimals for the interchain tokens. |
-| distributor | bytes | The distributor data for mint/burn operations. |
-| operator | bytes |  |
-| gasValue | uint256 | The gas value for deployment. |
-
-### tokenManagerImplementation
-
-```solidity
-function tokenManagerImplementation(uint256 tokenManagerType) external view returns (address tokenManagerAddress_)
-```
-
-Returns the implementation address for a given token manager type.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManagerType | uint256 | The type of token manager. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManagerAddress_ | address | The address of the token manager implementation. |
-
-### interchainTransfer
-
-```solidity
-function interchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
-```
-
-### callContractWithInterchainToken
-
-```solidity
-function callContractWithInterchainToken(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, bytes data) external payable
-```
-
-### transmitInterchainTransfer
-
-```solidity
-function transmitInterchainTransfer(bytes32 tokenId, address sourceAddress, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
-```
-
-Initiates an interchain token transfer. Only callable by TokenManagers
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The tokenId of the token to be transmitted. |
-| sourceAddress | address | The source address of the token. |
-| destinationChain | string | The name of the destination chain. |
-| destinationAddress | bytes | The destination address on the destination chain. |
-| amount | uint256 | The amount of tokens to transmit. |
-| metadata | bytes | The metadata associated with the transmission. |
-
-### setFlowLimits
-
-```solidity
-function setFlowLimits(bytes32[] tokenIds, uint256[] flowLimits) external
-```
-
-Sets the flow limits for multiple tokens.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenIds | bytes32[] | An array of tokenIds. |
-| flowLimits | uint256[] | An array of flow limits corresponding to the tokenIds. |
-
-### flowLimit
-
-```solidity
-function flowLimit(bytes32 tokenId) external view returns (uint256 flowLimit_)
-```
-
-Returns the flow limit for a specific token.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The tokenId of the token. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowLimit_ | uint256 | The flow limit for the token. |
-
-### flowOutAmount
-
-```solidity
-function flowOutAmount(bytes32 tokenId) external view returns (uint256 flowOutAmount_)
-```
-
-Returns the total amount of outgoing flow for a specific token.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The tokenId of the token. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowOutAmount_ | uint256 | The total amount of outgoing flow for the token. |
-
-### flowInAmount
-
-```solidity
-function flowInAmount(bytes32 tokenId) external view returns (uint256 flowInAmount_)
-```
-
-Returns the total amount of incoming flow for a specific token.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The tokenId of the token. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowInAmount_ | uint256 | The total amount of incoming flow for the token. |
-
-### setPauseStatus
-
-```solidity
-function setPauseStatus(bool paused) external
-```
-
-Allows the owner to pause/unpause the token service.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| paused | bool | whether to pause or unpause. |
-
-## IOperatable
-
-### transferOperatorship
-
-```solidity
-function transferOperatorship(address operator_) external
-```
-
-Change the operator of the contract
-
-_Can only be called by the current operator_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator_ | address | The address of the new operator |
-
-### proposeOperatorship
-
-```solidity
-function proposeOperatorship(address operator_) external
-```
-
-Proposed a change of the operator of the contract
-
-_Can only be called by the current operator_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator_ | address | The address of the new operator |
-
-### acceptOperatorship
-
-```solidity
-function acceptOperatorship(address fromOperator) external
-```
-
-Accept a proposed change of operatorship
-
-_Can only be called by the proposed operator_
-
-### isOperator
-
-```solidity
-function isOperator(address addr) external view returns (bool)
-```
-
-Query if an address is a operator
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| addr | address | the address to query for |
-
-## IInterchainToken
-
-This contract implements a interchain token which extends InterchainToken functionality.
-This contract also inherits Distributable and Implementation logic.
-
-### TokenManagerAddressZero
-
-```solidity
-error TokenManagerAddressZero()
-```
-
-### TokenNameEmpty
-
-```solidity
-error TokenNameEmpty()
-```
-
-### setup
-
-```solidity
-function setup(bytes params) external
-```
-
-Called by the proxy to setup itself.
-
-_This should be hidden by the proxy._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| params | bytes | the data to be used for the initialization. |
-
-### tokenManager
-
-```solidity
-function tokenManager() external view returns (contract ITokenManager tokenManager_)
-```
-
-Getter for the tokenManager used for this token.
-
-_Needs to be overwitten._
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManager_ | contract ITokenManager | the TokenManager called to facilitate cross chain transfers. |
-
-## ITokenManager
-
-This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
-
-### TokenLinkerZeroAddress
-
-```solidity
-error TokenLinkerZeroAddress()
-```
-
-### NotService
-
-```solidity
-error NotService(address caller)
-```
-
-### TakeTokenFailed
-
-```solidity
-error TakeTokenFailed()
-```
-
-### GiveTokenFailed
-
-```solidity
-error GiveTokenFailed()
-```
-
-### NotToken
-
-```solidity
-error NotToken(address caller)
-```
-
-### ZeroAddress
-
-```solidity
-error ZeroAddress()
-```
-
-### AlreadyFlowLimiter
-
-```solidity
-error AlreadyFlowLimiter(address flowLimiter)
-```
-
-### NotFlowLimiter
-
-```solidity
-error NotFlowLimiter(address flowLimiter)
-```
-
-### interchainTokenId
-
-```solidity
-function interchainTokenId() external view returns (bytes32)
-```
-
-A function that returns the token id.
-
-### tokenAddress
-
-```solidity
-function tokenAddress() external view returns (address)
-```
-
-A function that should return the address of the token.
-Must be overridden in the inheriting contract.
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | address | address address of the token. |
-
-### implementationType
-
-```solidity
-function implementationType() external pure returns (uint256)
-```
-
-A function that should return the implementation type of the token manager.
-
-### interchainTransfer
-
-```solidity
-function interchainTransfer(string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
-```
-
-Calls the service to initiate a cross-chain transfer after taking the appropriate amount of tokens from the user.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| destinationChain | string | the name of the chain to send tokens to. |
-| destinationAddress | bytes | the address of the user to send tokens to. |
-| amount | uint256 | the amount of tokens to take from msg.sender. |
-| metadata | bytes | any additional data to be sent with the transfer. |
-
-### callContractWithInterchainToken
-
-```solidity
-function callContractWithInterchainToken(string destinationChain, bytes destinationAddress, uint256 amount, bytes data) external payable
-```
-
-Calls the service to initiate a cross-chain transfer with data after taking the appropriate amount of tokens from the user.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| destinationChain | string | the name of the chain to send tokens to. |
-| destinationAddress | bytes | the address of the user to send tokens to. |
-| amount | uint256 | the amount of tokens to take from msg.sender. |
-| data | bytes | the data to pass to the destination contract. |
-
-### transmitInterchainTransfer
-
-```solidity
-function transmitInterchainTransfer(address sender, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
-```
-
-Calls the service to initiate a cross-chain transfer after taking the appropriate amount of tokens from the user. This can only be called by the token itself.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sender | address | the address of the user paying for the cross chain transfer. |
-| destinationChain | string | the name of the chain to send tokens to. |
-| destinationAddress | bytes | the address of the user to send tokens to. |
-| amount | uint256 | the amount of tokens to take from msg.sender. |
-| metadata | bytes | any additional data to be sent with the transfer. |
-
-### giveToken
-
-```solidity
-function giveToken(address destinationAddress, uint256 amount) external returns (uint256)
-```
-
-This function gives token to a specified address. Can only be called by the service.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| destinationAddress | address | the address to give tokens to. |
-| amount | uint256 | the amount of token to give. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | the amount of token actually given, which will only be different than `amount` in cases where the token takes some on-transfer fee. |
-
-### takeToken
-
-```solidity
-function takeToken(address sourceAddress, uint256 amount) external returns (uint256)
-```
-
-This function takes token to from a specified address. Can only be called by the service.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| sourceAddress | address | the address to take tokens from. |
-| amount | uint256 | the amount of token to take. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | the amount of token actually taken, which will onle be differen than `amount` in cases where the token takes some on-transfer fee. |
-
-### setFlowLimit
-
-```solidity
-function setFlowLimit(uint256 flowLimit_) external
-```
-
-This function sets the flow limit for this TokenManager. Can only be called by the operator.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowLimit_ | uint256 | the maximum difference between the tokens flowing in and/or out at any given interval of time (6h) |
-
-## ITokenManagerDeployer
-
-This contract is used to deploy new instances of the TokenManagerProxy contract.
-
-### AddressZero
-
-```solidity
-error AddressZero()
-```
-
-### TokenManagerDeploymentFailed
-
-```solidity
-error TokenManagerDeploymentFailed()
-```
-
-### deployTokenManager
-
-```solidity
-function deployTokenManager(bytes32 tokenId, uint256 implementationType, bytes params) external payable returns (address tokenManager)
-```
-
-Deploys a new instance of the TokenManagerProxy contract
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | bytes32 | The unique identifier for the token |
-| implementationType | uint256 | Token manager implementation type |
-| params | bytes | Additional parameters used in the setup of the token manager |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenManager | address | Address of the deployed tokenManager |
-
-## ITokenManagerLiquidityPool
-
-This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
-
-### params
-
-```solidity
-function params(bytes operator_, address tokenAddress_, address liquidityPool_) external pure returns (bytes params_)
-```
-
-Getter function for the parameters of a lock/unlock TokenManager. Mainly to be used by frontends.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator_ | bytes | the operator of the TokenManager. |
-| tokenAddress_ | address | the token to be managed. |
-| liquidityPool_ | address | he address of the liquidity pool. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| params_ | bytes | the resulting params to be passed to custom TokenManager deployments. |
-
-### liquidityPool
-
-```solidity
-function liquidityPool() external view returns (address liquidityPool_)
-```
-
-_Reads the stored liquidity pool address from the specified storage slot_
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| liquidityPool_ | address | The address of the liquidity pool |
-
-### setLiquidityPool
-
-```solidity
-function setLiquidityPool(address newLiquidityPool) external
-```
-
-_Updates the address of the liquidity pool. Can only be called by the operator._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| newLiquidityPool | address | The new address of the liquidity pool |
-
-## ITokenManagerLockUnlock
-
-This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
-
-### params
-
-```solidity
-function params(bytes operator_, address tokenAddress_) external pure returns (bytes params_)
-```
-
-Getter function for the parameters of a lock/unlock TokenManager. Mainly to be used by frontends.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator_ | bytes | the operator of the TokenManager. |
-| tokenAddress_ | address | the token to be managed. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| params_ | bytes | the resulting params to be passed to custom TokenManager deployments. |
-
-## ITokenManagerLockUnlockFee
-
-This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
-
-### params
-
-```solidity
-function params(bytes operator_, address tokenAddress_) external pure returns (bytes params_)
-```
-
-Getter function for the parameters of a lock/unlock TokenManager. Mainly to be used by frontends.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator_ | bytes | the operator of the TokenManager. |
-| tokenAddress_ | address | the token to be managed. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| params_ | bytes | the resulting params to be passed to custom TokenManager deployments. |
-
-## ITokenManagerMintBurn
-
-This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
-
-### params
-
-```solidity
-function params(bytes operator_, address tokenAddress_) external pure returns (bytes params_)
-```
-
-Getter function for the parameters of a lock/unlock TokenManager. Mainly to be used by frontends.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| operator_ | bytes | the operator of the TokenManager. |
-| tokenAddress_ | address | the token to be managed. |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| params_ | bytes | the resulting params to be passed to custom TokenManager deployments. |
-
-## ITokenManagerProxy
-
-_This contract is a proxy for token manager contracts. It implements ITokenManagerProxy and
-inherits from FixedProxy from the gmp sdk repo_
-
-### ImplementationLookupFailed
-
-```solidity
-error ImplementationLookupFailed()
-```
-
-### SetupFailed
-
-```solidity
-error SetupFailed(bytes returnData)
-```
-
-### NativeTokenNotAccepted
-
-```solidity
-error NativeTokenNotAccepted()
-```
-
-### implementationType
-
-```solidity
-function implementationType() external view returns (uint256)
-```
-
-Returns implementation type of this token manager
-
-### implementation
-
-```solidity
-function implementation() external view returns (address)
-```
-
-Returns the address of the current implementation.
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | address | impl The address of the current implementation |
-
-### interchainTokenId
-
-```solidity
-function interchainTokenId() external view returns (bytes32)
-```
-
-Returns token ID of the token manager.
-
-## ITokenManagerType
-
-A simple interface that defines all the token manager types
-
-### TokenManagerType
-
-```solidity
-enum TokenManagerType {
-  MINT_BURN,
-  MINT_BURN_FROM,
-  LOCK_UNLOCK,
-  LOCK_UNLOCK_FEE
-}
-```
-
-## IInterchainTokenFactory
-
-### ZeroAddress
-
-```solidity
-error ZeroAddress()
-```
-
-### NotDistributor
-
-```solidity
-error NotDistributor(address distributor)
-```
-
-### NotOperator
-
-```solidity
-error NotOperator(address operator)
-```
-
-### NonZeroMintAmount
-
-```solidity
-error NonZeroMintAmount()
-```
-
-### ApproveFailed
-
-```solidity
-error ApproveFailed()
-```
-
-### chainNameHash
-
-```solidity
-function chainNameHash() external view returns (bytes32)
-```
-
-### interchainTokenSalt
-
-```solidity
-function interchainTokenSalt(bytes32 chainAddressHash_, address deployer, bytes32 salt) external view returns (bytes32)
-```
-
-### interchainTokenId
-
-```solidity
-function interchainTokenId(address deployer, bytes32 salt) external view returns (bytes32 tokenId)
-```
-
-### interchainTokenAddress
-
-```solidity
-function interchainTokenAddress(address deployer, bytes32 salt) external view returns (address tokenAddress)
-```
-
-### deployInterchainToken
-
-```solidity
-function deployInterchainToken(bytes32 salt, string name, string symbol, uint8 decimals, uint256 mintAmount, address distributor, address operator) external payable
-```
-
-### deployRemoteInterchainToken
-
-```solidity
-function deployRemoteInterchainToken(string originalChainName, bytes32 salt, address additionalDistributor, address optionalOperator, string destinationChain, uint256 gasValue) external payable
-```
-
-### canonicalInterchainTokenSalt
-
-```solidity
-function canonicalInterchainTokenSalt(bytes32 chainAddressHash_, address tokenAddress) external view returns (bytes32 salt)
-```
-
-### canonicalInterchainTokenId
-
-```solidity
-function canonicalInterchainTokenId(address tokenAddress) external view returns (bytes32 tokenId)
-```
-
-### registerCanonicalInterchainToken
-
-```solidity
-function registerCanonicalInterchainToken(address tokenAddress) external payable returns (bytes32 tokenId)
-```
-
-### deployRemoteCanonicalInterchainToken
-
-```solidity
-function deployRemoteCanonicalInterchainToken(string originalChainName, address originalAddress, string destinationChain, uint256 gasValue) external payable
-```
-
-### interchainTransfer
-
-```solidity
-function interchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, uint256 gasValue) external payable
-```
-
-### interchainTransferFrom
-
-```solidity
-function interchainTransferFrom(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, uint256 gasValue) external payable
-```
-
-## CanonicalInterchainInterchainTokenFactoryProxy
-
-_Proxy contract for interchain token service contracts. Inherits from the Proxy contract._
-
-### constructor
-
-```solidity
-constructor(address implementationAddress, address owner) public
-```
-
-_Constructs the InterchainTokenServiceProxy contract._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| implementationAddress | address | Address of the interchain token service implementation |
-| owner | address | Address of the owner of the proxy |
-
-### contractId
-
-```solidity
-function contractId() internal pure returns (bytes32)
-```
-
-_Override for the 'contractId' function in FinalProxy. Returns a unique identifier for this contract._
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bytes32 | bytes32 identifier for this contract |
-
-## InterchainTokenServiceProxy
-
-_Proxy contract for interchain token service contracts. Inherits from the FinalProxy contract._
-
-### constructor
-
-```solidity
-constructor(address implementationAddress, address owner, address operator) public
-```
-
-_Constructs the InterchainTokenServiceProxy contract._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| implementationAddress | address | Address of the interchain token service implementation |
-| owner | address | Address of the owner of the proxy |
-| operator | address |  |
-
-### contractId
-
-```solidity
-function contractId() internal pure returns (bytes32)
-```
-
-_Override for the 'contractId' function in FinalProxy. Returns a unique identifier for this contract._
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bytes32 | bytes32 identifier for this contract |
-
-## InterchainTokenProxy
-
-_Proxy contract for InterchainToken contracts. Inherits from FixedProxy._
-
-### constructor
-
-```solidity
-constructor(address implementationAddress, bytes params) public
-```
-
-_Constructs the InterchainTokenProxy contract._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| implementationAddress | address | Address of the InterchainToken implementation |
-| params | bytes | Initialization parameters for the InterchainToken contract |
-
-### contractId
-
-```solidity
-function contractId() internal pure returns (bytes32)
-```
-
-Getter for the contract id.
-
-## TokenManagerProxy
-
-This contract is a proxy for token manager contracts.
-
-_It implements ITokenManagerProxy._
-
-### interchainTokenService
-
-```solidity
-contract IInterchainTokenService interchainTokenService
-```
-
-### implementationType
-
-```solidity
-uint256 implementationType
-```
-
-Returns implementation type of this token manager
-
-### interchainTokenId
-
-```solidity
-bytes32 interchainTokenId
-```
-
-Returns token ID of the token manager.
-
-### constructor
-
-```solidity
-constructor(address interchainTokenServiceAddress_, uint256 implementationType_, bytes32 tokenId, bytes params) public
-```
-
-_Constructs the TokenManagerProxy contract._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| interchainTokenServiceAddress_ | address | The address of the interchain token service |
-| implementationType_ | uint256 | The token manager type |
-| tokenId | bytes32 | The identifier for the token |
-| params | bytes | The initialization parameters for the token manager contract |
-
-### implementation
-
-```solidity
-function implementation() public view returns (address impl)
-```
-
-_Returns the address of the current implementation._
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| impl | address | The address of the current implementation |
-
-### _tokenManagerImplementation
-
-```solidity
-function _tokenManagerImplementation(contract IInterchainTokenService interchainTokenServiceAddress_, uint256 implementationType_) internal view returns (address impl)
-```
-
-_Returns the implementation address from the interchain token service for the provided type._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| interchainTokenServiceAddress_ | contract IInterchainTokenService | The address of the interchain token service |
-| implementationType_ | uint256 | The token manager type |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| impl | address | The address of the implementation |
-
-### setup
-
-```solidity
-function setup(bytes setupParams) external
-```
-
-_Setup function. Empty in this contract._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| setupParams | bytes | Initialization parameters |
-
-### receive
-
-```solidity
-receive() external payable virtual
-```
-
-_Reverts if native token is sent._
-
-### fallback
-
-```solidity
-fallback() external payable virtual
-```
-
-_Fallback function. Delegates the call to the token manager contract._
-
-## InterchainTokenFactoryProxy
-
-_Proxy contract for interchain token service contracts. Inherits from the Proxy contract._
-
-### constructor
-
-```solidity
-constructor(address implementationAddress, address owner) public
-```
-
-_Constructs the InterchainTokenServiceProxy contract._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| implementationAddress | address | Address of the interchain token service implementation |
-| owner | address | Address of the owner of the proxy |
-
-### contractId
-
-```solidity
-function contractId() internal pure returns (bytes32)
-```
-
-_Override for the 'contractId' function in FinalProxy. Returns a unique identifier for this contract._
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | bytes32 | bytes32 identifier for this contract |
-
-## FeeOnTransferTokenTest
-
-### tokenManager_
-
-```solidity
-contract ITokenManager tokenManager_
-```
-
-### tokenManagerRequiresApproval_
-
-```solidity
-bool tokenManagerRequiresApproval_
-```
-
-### name
-
-```solidity
-string name
-```
-
-### symbol
-
-```solidity
-string symbol
-```
-
-### decimals
-
-```solidity
-uint8 decimals
-```
-
-### constructor
-
-```solidity
-constructor(string name_, string symbol_, uint8 decimals_, address tokenManagerAddress) public
-```
-
-### tokenManager
-
-```solidity
-function tokenManager() public view returns (contract ITokenManager)
-```
-
-Getter for the tokenManager used for this token.
-
-_Needs to be overwritten._
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | contract ITokenManager |  |
-
-### _beforeInterchainTransfer
-
-```solidity
-function _beforeInterchainTransfer(address sender, string, bytes, uint256 amount, bytes) internal
-```
-
-### setTokenManagerRequiresApproval
-
-```solidity
-function setTokenManagerRequiresApproval(bool requiresApproval) public
-```
-
-### mint
-
-```solidity
-function mint(address account, uint256 amount) external
-```
-
-### burn
-
-```solidity
-function burn(address account, uint256 amount) external
-```
-
-### setTokenManager
-
-```solidity
-function setTokenManager(contract ITokenManager tokenManagerAddress) external
-```
-
-### _transfer
-
-```solidity
-function _transfer(address sender, address recipient, uint256 amount) internal
-```
-
-_Moves tokens `amount` from `sender` to `recipient`.
-
-This is internal function is equivalent to {transfer}, and can be used to
-e.g. implement automatic token fees, slashing mechanisms, etc.
-
-Emits a {Transfer} event.
-
-Requirements:
-
-- `sender` cannot be the zero address.
-- `recipient` cannot be the zero address.
-- `sender` must have a balance of at least `amount`._
-
-## Invalid
-
-```solidity
-error Invalid()
-```
-
-## TestTokenManager
-
-### NAME
-
-```solidity
-string NAME
-```
-
-### constructor
-
-```solidity
-constructor(address interchainTokenService_) public
-```
-
-## TestDistributable
-
-### NAME
-
-```solidity
-string NAME
-```
-
-### constructor
-
-```solidity
-constructor() public
-```
-
-## TestFlowLimit
-
-### NAME
-
-```solidity
-string NAME
-```
-
-### constructor
-
-```solidity
-constructor() public
-```
-
-## TestOperatable
-
-### NAME
-
-```solidity
-string NAME
-```
-
-### constructor
-
-```solidity
-constructor() public
-```
-
-## InterchainExecutableTest
-
-### MessageReceived
-
-```solidity
-event MessageReceived(string sourceChain, bytes sourceAddress, address receiver, string message, bytes32 tokenId, uint256 amount)
-```
-
-### constructor
-
-```solidity
-constructor(address interchainTokenService_) public
-```
-
-### lastMessage
-
-```solidity
-string lastMessage
-```
-
-### _executeWithInterchainToken
-
-```solidity
-function _executeWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) internal
-```
-
-## InterchainTokenTest
-
-### tokenManager_
-
-```solidity
-contract ITokenManager tokenManager_
-```
-
-### tokenManagerRequiresApproval_
-
-```solidity
-bool tokenManagerRequiresApproval_
-```
-
-### name
-
-```solidity
-string name
-```
-
-### symbol
-
-```solidity
-string symbol
-```
-
-### decimals
-
-```solidity
-uint8 decimals
-```
-
-### constructor
-
-```solidity
-constructor(string name_, string symbol_, uint8 decimals_, address tokenManagerAddress) public
-```
-
-### tokenManager
-
-```solidity
-function tokenManager() public view returns (contract ITokenManager)
-```
-
-Getter for the tokenManager used for this token.
-
-_Needs to be overwritten._
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | contract ITokenManager |  |
-
-### _beforeInterchainTransfer
-
-```solidity
-function _beforeInterchainTransfer(address sender, string, bytes, uint256 amount, bytes) internal
-```
-
-### setTokenManagerRequiresApproval
-
-```solidity
-function setTokenManagerRequiresApproval(bool requiresApproval) public
-```
-
-### mint
-
-```solidity
-function mint(address account, uint256 amount) external
-```
-
-### burn
-
-```solidity
-function burn(address account, uint256 amount) external
-```
-
-### setTokenManager
-
-```solidity
-function setTokenManager(contract ITokenManager tokenManagerAddress) external
-```
-
-## InvalidInterchainToken
-
-### name
-
-```solidity
-string name
-```
-
-### symbol
-
-```solidity
-string symbol
-```
-
-### decimals
-
-```solidity
-uint8 decimals
-```
-
-### tokenManager_
-
-```solidity
-address tokenManager_
-```
-
-### contractId
-
-```solidity
-function contractId() external pure returns (bytes32)
-```
-
-Getter for the contract id.
-
-### tokenManager
-
-```solidity
-function tokenManager() public view returns (contract ITokenManager)
-```
-
-Returns the token manager for this token
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | contract ITokenManager | ITokenManager The token manager contract |
-
-### setup
-
-```solidity
-function setup(bytes params) external
-```
-
-Setup function to initialize contract parameters
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| params | bytes | The setup parameters in bytes The setup params include tokenManager, distributor, tokenName, symbol, decimals, mintAmount and mintTo |
-
-### mint
-
-```solidity
-function mint(address account, uint256 amount) external
-```
-
-Function to mint new tokens
-Can only be called by the distributor address.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| account | address | The address that will receive the minted tokens |
-| amount | uint256 | The amount of tokens to mint |
-
-### burn
-
-```solidity
-function burn(address account, uint256 amount) external
-```
-
-Function to burn tokens
-Can only be called by the distributor address.
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| account | address | The address that will have its tokens burnt |
-| amount | uint256 | The amount of tokens to burn |
-
-## DistributableTest
-
-### nonce
-
-```solidity
-uint256 nonce
-```
-
-### constructor
-
-```solidity
-constructor(address distributor) public
-```
-
-### testDistributable
-
-```solidity
-function testDistributable() external
-```
-
-### distributorRole
-
-```solidity
-function distributorRole() external pure returns (uint8)
-```
-
-## FlowLimitTest
-
-### TOKEN_ID
-
-```solidity
-bytes32 TOKEN_ID
-```
-
-### setFlowLimit
-
-```solidity
-function setFlowLimit(uint256 flowLimit) external
-```
-
-### addFlowIn
-
-```solidity
-function addFlowIn(uint256 flowInAmount) external
-```
-
-### addFlowOut
-
-```solidity
-function addFlowOut(uint256 flowOutAmount) external
-```
-
-## FlowLimitTestLiveNetwork
-
-### FLOW_LIMIT_SLOT
-
-```solidity
-uint256 FLOW_LIMIT_SLOT
-```
-
-### PREFIX_FLOW_OUT_AMOUNT
-
-```solidity
-uint256 PREFIX_FLOW_OUT_AMOUNT
-```
-
-### PREFIX_FLOW_IN_AMOUNT
-
-```solidity
-uint256 PREFIX_FLOW_IN_AMOUNT
-```
-
-### TOKEN_ID
-
-```solidity
-bytes32 TOKEN_ID
-```
-
-### EPOCH_TIME
-
-```solidity
-uint256 EPOCH_TIME
-```
-
-### flowLimit
-
-```solidity
-function flowLimit() public view returns (uint256 flowLimit_)
-```
-
-Returns the current flow limit
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowLimit_ | uint256 | The current flow limit value |
-
-### _setFlowLimit
-
-```solidity
-function _setFlowLimit(uint256 flowLimit_) internal
-```
-
-### _getFlowOutSlot
-
-```solidity
-function _getFlowOutSlot(uint256 epoch) internal pure returns (uint256 slot)
-```
-
-### _getFlowInSlot
-
-```solidity
-function _getFlowInSlot(uint256 epoch) internal pure returns (uint256 slot)
-```
-
-### flowOutAmount
-
-```solidity
-function flowOutAmount() external view returns (uint256 flowOutAmount_)
-```
-
-Returns the current flow out amount
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowOutAmount_ | uint256 | The current flow out amount |
-
-### flowInAmount
-
-```solidity
-function flowInAmount() external view returns (uint256 flowInAmount_)
-```
-
-Returns the current flow in amount
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| flowInAmount_ | uint256 | The current flow in amount |
-
-### _addFlow
-
-```solidity
-function _addFlow(uint256 flowLimit_, uint256 slotToAdd, uint256 slotToCompare, uint256 flowAmount) internal
-```
-
-### _addFlowOut
-
-```solidity
-function _addFlowOut(uint256 flowOutAmount_) internal
-```
-
-### _addFlowIn
-
-```solidity
-function _addFlowIn(uint256 flowInAmount_) internal
-```
-
-### setFlowLimit
-
-```solidity
-function setFlowLimit(uint256 flowLimit_) external
-```
-
-### addFlowIn
-
-```solidity
-function addFlowIn(uint256 flowInAmount_) external
-```
-
-### addFlowOut
-
-```solidity
-function addFlowOut(uint256 flowOutAmount_) external
-```
-
-## ImplementationTest
-
-### val
-
-```solidity
-uint256 val
-```
-
-### setup
-
-```solidity
-function setup(bytes params) external
-```
-
-Called by the proxy to setup itself.
-
-_This should be hidden by the proxy._
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| params | bytes | the data to be used for the initialization. |
-
-## NakedProxy
-
-### implementation
-
-```solidity
-address implementation
-```
-
-### constructor
-
-```solidity
-constructor(address implementation_) public
-```
-
-### fallback
-
-```solidity
-fallback() external payable virtual
-```
-
-### receive
-
-```solidity
-receive() external payable virtual
-```
-
-## OperatorableTest
-
-### nonce
-
-```solidity
-uint256 nonce
-```
-
-### constructor
-
-```solidity
-constructor(address operator) public
-```
-
-### testOperatorable
-
-```solidity
-function testOperatorable() external
-```
-
-### operatorRole
-
-```solidity
-function operatorRole() external pure returns (uint8)
-```
 
 ## ERC20
 
@@ -3918,7 +427,7 @@ Getter for the contract id.
 ### tokenManager
 
 ```solidity
-function tokenManager() public view returns (contract ITokenManager)
+function tokenManager() public view returns (address)
 ```
 
 Returns the token manager for this token
@@ -3927,7 +436,7 @@ Returns the token manager for this token
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | contract ITokenManager | ITokenManager The token manager contract |
+| [0] | address | address The token manager contract |
 
 ### setup
 
@@ -3975,6 +484,3339 @@ Can only be called by the distributor address.
 | account | address | The address that will have its tokens burnt |
 | amount | uint256 | The amount of tokens to burn |
 
+## IDistributable
+
+### transferDistributorship
+
+```solidity
+function transferDistributorship(address distributor_) external
+```
+
+Change the distributor of the contract
+
+_Can only be called by the current distributor_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| distributor_ | address | The address of the new distributor |
+
+### proposeDistributorship
+
+```solidity
+function proposeDistributorship(address distributor_) external
+```
+
+Proposed a change of the distributor of the contract
+
+_Can only be called by the current distributor_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| distributor_ | address | The address of the new distributor |
+
+### acceptDistributorship
+
+```solidity
+function acceptDistributorship(address fromDistributor) external
+```
+
+Accept a change of the distributor of the contract
+
+_Can only be called by the proposed distributor_
+
+### isDistributor
+
+```solidity
+function isDistributor(address addr) external view returns (bool)
+```
+
+Query if an address is a distributor
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| addr | address | the address to query for |
+
+## IERC20MintableBurnable
+
+_Interface of the ERC20 standard as defined in the EIP._
+
+### mint
+
+```solidity
+function mint(address to, uint256 amount) external
+```
+
+Function to mint new tokens
+
+_Can only be called by the distributor address._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| to | address | The address that will receive the minted tokens |
+| amount | uint256 | The amount of tokens to mint |
+
+### burn
+
+```solidity
+function burn(address from, uint256 amount) external
+```
+
+Function to burn tokens
+
+_Can only be called by the distributor address._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| from | address | The address that will have its tokens burnt |
+| amount | uint256 | The amount of tokens to burn |
+
+## IERC20Named
+
+_Interface of the ERC20 standard as defined in the EIP._
+
+### name
+
+```solidity
+function name() external view returns (string)
+```
+
+Getter for the name of the token
+
+### symbol
+
+```solidity
+function symbol() external view returns (string)
+```
+
+Getter for the symbol of the token
+
+### decimals
+
+```solidity
+function decimals() external view returns (uint8)
+```
+
+Getter for the decimals of the token
+
+## IFlowLimit
+
+### FlowLimitExceeded
+
+```solidity
+error FlowLimitExceeded(uint256 limit, uint256 flowAmount)
+```
+
+### FlowLimitSet
+
+```solidity
+event FlowLimitSet(bytes32 tokenId, address operator, uint256 flowLimit_)
+```
+
+### flowLimit
+
+```solidity
+function flowLimit() external view returns (uint256 flowLimit_)
+```
+
+Returns the current flow limit
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowLimit_ | uint256 | The current flow limit value |
+
+### flowOutAmount
+
+```solidity
+function flowOutAmount() external view returns (uint256 flowOutAmount_)
+```
+
+Returns the current flow out amount
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowOutAmount_ | uint256 | The current flow out amount |
+
+### flowInAmount
+
+```solidity
+function flowInAmount() external view returns (uint256 flowInAmount_)
+```
+
+Returns the current flow in amount
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowInAmount_ | uint256 | The current flow in amount |
+
+## IInterchainToken
+
+### TokenManagerAddressZero
+
+```solidity
+error TokenManagerAddressZero()
+```
+
+### TokenNameEmpty
+
+```solidity
+error TokenNameEmpty()
+```
+
+### tokenManager
+
+```solidity
+function tokenManager() external view returns (address tokenManager_)
+```
+
+Getter for the tokenManager used for this token.
+
+_Needs to be overwitten._
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManager_ | address | the TokenManager called to facilitate cross chain transfers. |
+
+## IInterchainTokenStandard
+
+_Interface of the ERC20 standard as defined in the EIP._
+
+### interchainTransfer
+
+```solidity
+function interchainTransfer(string destinationChain, bytes recipient, uint256 amount, bytes metadata) external payable
+```
+
+Implementation of the interchainTransfer method
+
+_We chose to either pass `metadata` as raw data on a remote contract call, or, if no data is passed, just do a transfer.
+A different implementation could have `metadata` that tells this function which function to use or that it is used for anything else as well._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| destinationChain | string | The destination chain identifier. |
+| recipient | bytes | The bytes representation of the address of the recipient. |
+| amount | uint256 | The amount of token to be transferred. |
+| metadata | bytes | Either empty, to just facilitate an interchain transfer, or the data can be passed for an interchain contract call with transfer as per semantics defined by the token service. |
+
+### interchainTransferFrom
+
+```solidity
+function interchainTransferFrom(address sender, string destinationChain, bytes recipient, uint256 amount, bytes metadata) external payable
+```
+
+Implementation of the interchainTransferFrom method
+
+_We chose to either pass `metadata` as raw data on a remote contract call, or, if no data is passed, just do a transfer.
+A different implementation could have `metadata` that tells this function which function to use or that it is used for anything else as well._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sender | address | the sender of the tokens. They need to have approved `msg.sender` before this is called. |
+| destinationChain | string | the string representation of the destination chain. |
+| recipient | bytes | the bytes representation of the address of the recipient. |
+| amount | uint256 | the amount of token to be transferred. |
+| metadata | bytes | either empty, to just facilitate a cross-chain transfer, or the data to be passed to a cross-chain contract call and transfer. |
+
+## IOperatable
+
+### transferOperatorship
+
+```solidity
+function transferOperatorship(address operator_) external
+```
+
+Change the operator of the contract
+
+_Can only be called by the current operator_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| operator_ | address | The address of the new operator |
+
+### proposeOperatorship
+
+```solidity
+function proposeOperatorship(address operator_) external
+```
+
+Proposed a change of the operator of the contract
+
+_Can only be called by the current operator_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| operator_ | address | The address of the new operator |
+
+### acceptOperatorship
+
+```solidity
+function acceptOperatorship(address fromOperator) external
+```
+
+Accept a proposed change of operatorship
+
+_Can only be called by the proposed operator_
+
+### isOperator
+
+```solidity
+function isOperator(address addr) external view returns (bool)
+```
+
+Query if an address is a operator
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| addr | address | the address to query for |
+
+## ITokenManager
+
+This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
+
+### TokenLinkerZeroAddress
+
+```solidity
+error TokenLinkerZeroAddress()
+```
+
+### NotService
+
+```solidity
+error NotService(address caller)
+```
+
+### TakeTokenFailed
+
+```solidity
+error TakeTokenFailed()
+```
+
+### GiveTokenFailed
+
+```solidity
+error GiveTokenFailed()
+```
+
+### NotToken
+
+```solidity
+error NotToken(address caller)
+```
+
+### ZeroAddress
+
+```solidity
+error ZeroAddress()
+```
+
+### AlreadyFlowLimiter
+
+```solidity
+error AlreadyFlowLimiter(address flowLimiter)
+```
+
+### NotFlowLimiter
+
+```solidity
+error NotFlowLimiter(address flowLimiter)
+```
+
+### interchainTokenId
+
+```solidity
+function interchainTokenId() external view returns (bytes32)
+```
+
+A function that returns the token id.
+
+### tokenAddress
+
+```solidity
+function tokenAddress() external view returns (address)
+```
+
+A function that should return the address of the token.
+Must be overridden in the inheriting contract.
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | address | address address of the token. |
+
+### implementationType
+
+```solidity
+function implementationType() external pure returns (uint256)
+```
+
+A function that should return the implementation type of the token manager.
+
+### interchainTransfer
+
+```solidity
+function interchainTransfer(string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
+```
+
+Calls the service to initiate a cross-chain transfer after taking the appropriate amount of tokens from the user.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| destinationChain | string | the name of the chain to send tokens to. |
+| destinationAddress | bytes | the address of the user to send tokens to. |
+| amount | uint256 | the amount of tokens to take from msg.sender. |
+| metadata | bytes | any additional data to be sent with the transfer. |
+
+### callContractWithInterchainToken
+
+```solidity
+function callContractWithInterchainToken(string destinationChain, bytes destinationAddress, uint256 amount, bytes data) external payable
+```
+
+Calls the service to initiate a cross-chain transfer with data after taking the appropriate amount of tokens from the user.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| destinationChain | string | the name of the chain to send tokens to. |
+| destinationAddress | bytes | the address of the user to send tokens to. |
+| amount | uint256 | the amount of tokens to take from msg.sender. |
+| data | bytes | the data to pass to the destination contract. |
+
+### transmitInterchainTransfer
+
+```solidity
+function transmitInterchainTransfer(address sender, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
+```
+
+Calls the service to initiate a cross-chain transfer after taking the appropriate amount of tokens from the user. This can only be called by the token itself.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sender | address | the address of the user paying for the cross chain transfer. |
+| destinationChain | string | the name of the chain to send tokens to. |
+| destinationAddress | bytes | the address of the user to send tokens to. |
+| amount | uint256 | the amount of tokens to take from msg.sender. |
+| metadata | bytes | any additional data to be sent with the transfer. |
+
+### giveToken
+
+```solidity
+function giveToken(address destinationAddress, uint256 amount) external returns (uint256)
+```
+
+This function gives token to a specified address. Can only be called by the service.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| destinationAddress | address | the address to give tokens to. |
+| amount | uint256 | the amount of token to give. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | uint256 | the amount of token actually given, which will only be different than `amount` in cases where the token takes some on-transfer fee. |
+
+### takeToken
+
+```solidity
+function takeToken(address sourceAddress, uint256 amount) external returns (uint256)
+```
+
+This function takes token to from a specified address. Can only be called by the service.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sourceAddress | address | the address to take tokens from. |
+| amount | uint256 | the amount of token to take. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | uint256 | the amount of token actually taken, which will onle be differen than `amount` in cases where the token takes some on-transfer fee. |
+
+### addFlowLimiter
+
+```solidity
+function addFlowLimiter(address flowLimiter) external
+```
+
+This function adds a flow limiter for this TokenManager. Can only be called by the operator.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowLimiter | address | the address of the new flow limiter. |
+
+### removeFlowLimiter
+
+```solidity
+function removeFlowLimiter(address flowLimiter) external
+```
+
+This function removes a flow limiter for this TokenManager. Can only be called by the operator.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowLimiter | address | the address of an existing flow limiter. |
+
+### setFlowLimit
+
+```solidity
+function setFlowLimit(uint256 flowLimit_) external
+```
+
+This function sets the flow limit for this TokenManager. Can only be called by the operator.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowLimit_ | uint256 | the maximum difference between the tokens flowing in and/or out at any given interval of time (6h) |
+
+## ITokenManagerType
+
+A simple interface that defines all the token manager types
+
+### TokenManagerType
+
+```solidity
+enum TokenManagerType {
+  MINT_BURN,
+  MINT_BURN_FROM,
+  LOCK_UNLOCK,
+  LOCK_UNLOCK_FEE
+}
+```
+
+## InvalidInterchainToken
+
+### name
+
+```solidity
+string name
+```
+
+### symbol
+
+```solidity
+string symbol
+```
+
+### decimals
+
+```solidity
+uint8 decimals
+```
+
+### tokenManager_
+
+```solidity
+address tokenManager_
+```
+
+### contractId
+
+```solidity
+function contractId() external pure returns (bytes32)
+```
+
+Getter for the contract id.
+
+### tokenManager
+
+```solidity
+function tokenManager() public view returns (address)
+```
+
+Returns the token manager for this token
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | address | address The token manager contract |
+
+### setup
+
+```solidity
+function setup(bytes params) external
+```
+
+Setup function to initialize contract parameters
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| params | bytes | The setup parameters in bytes The setup params include tokenManager, distributor, tokenName, symbol, decimals, mintAmount and mintTo |
+
+### mint
+
+```solidity
+function mint(address account, uint256 amount) external
+```
+
+Function to mint new tokens
+Can only be called by the distributor address.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| account | address | The address that will receive the minted tokens |
+| amount | uint256 | The amount of tokens to mint |
+
+### burn
+
+```solidity
+function burn(address account, uint256 amount) external
+```
+
+Function to burn tokens
+Can only be called by the distributor address.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| account | address | The address that will have its tokens burnt |
+| amount | uint256 | The amount of tokens to burn |
+
+## Distributable
+
+_A contract module which provides a basic access control mechanism, where
+there is an account (a distributor) that can be granted exclusive access to
+specific functions. This module is used through inheritance._
+
+### _addDistributor
+
+```solidity
+function _addDistributor(address distributor_) internal
+```
+
+_Internal function that stores the new distributor address in the correct storage slot_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| distributor_ | address | The address of the new distributor |
+
+### transferDistributorship
+
+```solidity
+function transferDistributorship(address distributor_) external
+```
+
+Change the distributor of the contract
+
+_Can only be called by the current distributor_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| distributor_ | address | The address of the new distributor |
+
+### proposeDistributorship
+
+```solidity
+function proposeDistributorship(address distributor_) external
+```
+
+Proposed a change of the distributor of the contract
+
+_Can only be called by the current distributor_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| distributor_ | address | The address of the new distributor |
+
+### acceptDistributorship
+
+```solidity
+function acceptDistributorship(address fromDistributor) external
+```
+
+Accept a change of the distributor of the contract
+
+_Can only be called by the proposed distributor_
+
+### isDistributor
+
+```solidity
+function isDistributor(address addr) external view returns (bool)
+```
+
+Query if an address is a distributor
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| addr | address | the address to query for |
+
+## RolesConstants
+
+### Roles
+
+```solidity
+enum Roles {
+  DISTRIBUTOR,
+  OPERATOR,
+  FLOW_LIMITER
+}
+```
+
+## InterchainTokenFactory
+
+### service
+
+```solidity
+contract IInterchainTokenService service
+```
+
+### chainNameHash
+
+```solidity
+bytes32 chainNameHash
+```
+
+### PREFIX_CANONICAL_TOKEN_SALT
+
+```solidity
+bytes32 PREFIX_CANONICAL_TOKEN_SALT
+```
+
+### PREFIX_INTERCHAIN_TOKEN_SALT
+
+```solidity
+bytes32 PREFIX_INTERCHAIN_TOKEN_SALT
+```
+
+### constructor
+
+```solidity
+constructor(address interchainTokenServiceAddress) public
+```
+
+### contractId
+
+```solidity
+function contractId() external pure returns (bytes32)
+```
+
+Getter for the contract id.
+
+### interchainTokenSalt
+
+```solidity
+function interchainTokenSalt(bytes32 chainNameHash_, address deployer, bytes32 salt) public pure returns (bytes32)
+```
+
+### canonicalInterchainTokenSalt
+
+```solidity
+function canonicalInterchainTokenSalt(bytes32 chainNameHash_, address tokenAddress) public pure returns (bytes32 salt)
+```
+
+### interchainTokenId
+
+```solidity
+function interchainTokenId(address deployer, bytes32 salt) public view returns (bytes32 tokenId)
+```
+
+### canonicalInterchainTokenId
+
+```solidity
+function canonicalInterchainTokenId(address tokenAddress) public view returns (bytes32 tokenId)
+```
+
+### interchainTokenAddress
+
+```solidity
+function interchainTokenAddress(address deployer, bytes32 salt) public view returns (address tokenAddress)
+```
+
+### deployInterchainToken
+
+```solidity
+function deployInterchainToken(bytes32 salt, string name, string symbol, uint8 decimals, uint256 mintAmount, address distributor) external payable
+```
+
+### deployRemoteInterchainToken
+
+```solidity
+function deployRemoteInterchainToken(string originalChainName, bytes32 salt, address additionalDistributor, string destinationChain, uint256 gasValue) external payable
+```
+
+### _deployInterchainToken
+
+```solidity
+function _deployInterchainToken(bytes32 salt, string destinationChain, string tokenName, string tokenSymbol, uint8 tokenDecimals, bytes distributor, uint256 gasValue) internal
+```
+
+### registerCanonicalInterchainToken
+
+```solidity
+function registerCanonicalInterchainToken(address tokenAddress) external payable returns (bytes32 tokenId)
+```
+
+### deployRemoteCanonicalInterchainToken
+
+```solidity
+function deployRemoteCanonicalInterchainToken(string originalChain, address originalTokenAddress, string destinationChain, uint256 gasValue) external payable
+```
+
+### interchainTransfer
+
+```solidity
+function interchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, uint256 gasValue) external payable
+```
+
+### tokenTransferFrom
+
+```solidity
+function tokenTransferFrom(bytes32 tokenId, uint256 amount) external payable
+```
+
+### tokenApprove
+
+```solidity
+function tokenApprove(bytes32 tokenId, uint256 amount) external payable
+```
+
+## InterchainTokenService
+
+This contract is responsible for facilitating cross chain token transfers.
+It (mostly) does not handle tokens, but is responsible for the messaging that needs to occur for cross chain transfers to happen.
+
+_The only storage used here is for ExpressCalls_
+
+### gateway
+
+```solidity
+contract IAxelarGateway gateway
+```
+
+### gasService
+
+```solidity
+contract IAxelarGasService gasService
+```
+
+### interchainTokenFactory
+
+```solidity
+address interchainTokenFactory
+```
+
+### chainNameHash
+
+```solidity
+bytes32 chainNameHash
+```
+
+Returns hash of the chain name.
+
+### interchainTokenDeployer
+
+```solidity
+address interchainTokenDeployer
+```
+
+Returns the address of the interchain token deployer contract.
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+
+### tokenManagerDeployer
+
+```solidity
+address tokenManagerDeployer
+```
+
+Returns the address of the token manager deployer contract.
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+
+### implementationMintBurn
+
+```solidity
+address implementationMintBurn
+```
+
+_Token manager implementation addresses_
+
+### implementationMintBurnFrom
+
+```solidity
+address implementationMintBurnFrom
+```
+
+### implementationLockUnlock
+
+```solidity
+address implementationLockUnlock
+```
+
+### implementationLockUnlockFee
+
+```solidity
+address implementationLockUnlockFee
+```
+
+### PREFIX_INTERCHAIN_TOKEN_ID
+
+```solidity
+bytes32 PREFIX_INTERCHAIN_TOKEN_ID
+```
+
+### PREFIX_INTERCHAIN_TOKEN_SALT
+
+```solidity
+bytes32 PREFIX_INTERCHAIN_TOKEN_SALT
+```
+
+### constructor
+
+```solidity
+constructor(address tokenManagerDeployer_, address interchainTokenDeployer_, address gateway_, address gasService_, address interchainTokenFactory_, string chainName_, address[] tokenManagerImplementations) public
+```
+
+_All of the variables passed here are stored as immutable variables._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManagerDeployer_ | address | the address of the TokenManagerDeployer. |
+| interchainTokenDeployer_ | address | the address of the InterchainTokenDeployer. |
+| gateway_ | address | the address of the AxelarGateway. |
+| gasService_ | address | the address of the AxelarGasService. |
+| interchainTokenFactory_ | address |  |
+| chainName_ | string | the name of the chain that this contract is deployed on. |
+| tokenManagerImplementations | address[] | this needs to have implementations in the order: Mint-burn, Mint-burn from, Lock-unlock, and Lock-unlock with fee. |
+
+### onlyRemoteService
+
+```solidity
+modifier onlyRemoteService(string sourceChain, string sourceAddress)
+```
+
+This modifier is used to ensure that only a remote InterchainTokenService can _execute this one.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sourceChain | string | the source of the contract call. |
+| sourceAddress | string | the address that the call came from. |
+
+### onlyTokenManager
+
+```solidity
+modifier onlyTokenManager(bytes32 tokenId)
+```
+
+This modifier is used to ensure certain functions can only be called by TokenManagers.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the `tokenId` of the TokenManager trying to perform the call. |
+
+### contractId
+
+```solidity
+function contractId() external pure returns (bytes32)
+```
+
+Getter for the contract id.
+
+### tokenManagerAddress
+
+```solidity
+function tokenManagerAddress(bytes32 tokenId) public view returns (address tokenManagerAddress_)
+```
+
+Calculates the address of a TokenManager from a specific tokenId. The TokenManager does not need to exist already.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the tokenId. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManagerAddress_ | address | deployment address of the TokenManager. |
+
+### validTokenManagerAddress
+
+```solidity
+function validTokenManagerAddress(bytes32 tokenId) public view returns (address tokenManagerAddress_)
+```
+
+Returns the address of a TokenManager from a specific tokenId. The TokenManager needs to exist already.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the tokenId. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManagerAddress_ | address | deployment address of the TokenManager. |
+
+### tokenAddress
+
+```solidity
+function tokenAddress(bytes32 tokenId) external view returns (address tokenAddress_)
+```
+
+Returns the address of the token that an existing tokenManager points to.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the tokenId. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenAddress_ | address | the address of the token. |
+
+### interchainTokenAddress
+
+```solidity
+function interchainTokenAddress(bytes32 tokenId) public view returns (address tokenAddress_)
+```
+
+Returns the address of the interchain token that would be deployed with a given tokenId.
+The token does not need to exist.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the tokenId. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenAddress_ | address | the address of the interchain token. |
+
+### interchainTokenId
+
+```solidity
+function interchainTokenId(address sender, bytes32 salt) public pure returns (bytes32 tokenId)
+```
+
+Calculates the tokenId that would correspond to a link for a given deployer with a specified salt.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sender | address | the address of the TokenManager deployer. |
+| salt | bytes32 | the salt that the deployer uses for the deployment. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the tokenId that the custom TokenManager would get (or has gotten). |
+
+### tokenManagerImplementation
+
+```solidity
+function tokenManagerImplementation(uint256 tokenManagerType) external view returns (address)
+```
+
+Getter function for TokenManager implementations. This will mainly be called by TokenManagerProxies
+to figure out their implementations
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManagerType | uint256 | the type of the TokenManager. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | address | tokenManagerAddress the address of the TokenManagerImplementation. |
+
+### flowLimit
+
+```solidity
+function flowLimit(bytes32 tokenId) external view returns (uint256 flowLimit_)
+```
+
+Getter function for the flow limit of an existing token manager with a give token ID.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the token ID of the TokenManager. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowLimit_ | uint256 | the flow limit. |
+
+### flowOutAmount
+
+```solidity
+function flowOutAmount(bytes32 tokenId) external view returns (uint256 flowOutAmount_)
+```
+
+Getter function for the flow out amount of an existing token manager with a give token ID.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the token ID of the TokenManager. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowOutAmount_ | uint256 | the flow out amount. |
+
+### flowInAmount
+
+```solidity
+function flowInAmount(bytes32 tokenId) external view returns (uint256 flowInAmount_)
+```
+
+Getter function for the flow in amount of an existing token manager with a give token ID.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the token ID of the TokenManager. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowInAmount_ | uint256 | the flow in amount. |
+
+### deployTokenManager
+
+```solidity
+function deployTokenManager(bytes32 salt, string destinationChain, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params, uint256 gasValue) external payable returns (bytes32 tokenId)
+```
+
+Used to deploy remote custom TokenManagers.
+
+_`gasValue` exists because this function can be part of a multicall involving multiple functions
+that could make remote contract calls._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| salt | bytes32 | the salt to be used. |
+| destinationChain | string | the name of the chain to deploy the TokenManager and interchain token to. |
+| tokenManagerType | enum ITokenManagerType.TokenManagerType | the type of TokenManager to be deployed. |
+| params | bytes | the params that will be used to initialize the TokenManager. |
+| gasValue | uint256 | the amount of native tokens to be used to pay for gas for the remote deployment. At least the amount specified needs to be passed to the call |
+
+### deployInterchainToken
+
+```solidity
+function deployInterchainToken(bytes32 salt, string destinationChain, string name, string symbol, uint8 decimals, bytes distributor, uint256 gasValue) external payable
+```
+
+Used to deploy a interchain token alongside a TokenManager in another chain. If the `distributor` is empty
+bytes then a mint/burn TokenManager is used. Otherwise a lock/unlock TokenManager is used.
+
+_`gasValue` exists because this function can be part of a multicall involving multiple functions that could make remote contract calls._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| salt | bytes32 | the salt to be used. |
+| destinationChain | string | the name of the destination chain to deploy to. |
+| name | string | the name of the token to be deployed. |
+| symbol | string | the symbol of the token to be deployed. |
+| decimals | uint8 | the decimals of the token to be deployed. |
+| distributor | bytes | the address that will be able to mint and burn the deployed token. |
+| gasValue | uint256 | the amount of native tokens to be used to pay for gas for the remote deployment. At least the amount specified needs to be passed to the call |
+
+### contractCallValue
+
+```solidity
+function contractCallValue(string sourceChain, string sourceAddress, bytes payload) public view virtual returns (address, uint256)
+```
+
+_Returns the value (token address and amount) associated with a contract call_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sourceChain | string | The source blockchain. |
+| sourceAddress | string | The source address. |
+| payload | bytes | The payload data. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | address |  |
+| [1] | uint256 |  |
+
+### expressExecute
+
+```solidity
+function expressExecute(bytes32 commandId, string sourceChain, string sourceAddress, bytes payload) external payable
+```
+
+Express executes a contract call.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| commandId | bytes32 | The commandId for the contractCall. |
+| sourceChain | string | The source chain. |
+| sourceAddress | string | The source address. |
+| payload | bytes | The payload data. |
+
+### _expressExecute
+
+```solidity
+function _expressExecute(string sourceChain, bytes payload) internal
+```
+
+Uses the caller's tokens to fullfill a sendCall ahead of time. Use this only if you have detected an outgoing
+interchainTransfer that matches the parameters passed here.
+
+_This is not to be used with fee on transfer tokens as it will incur losses for the express caller._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sourceChain | string | the name of the chain where the interchainTransfer originated from. |
+| payload | bytes | the payload of the receive token |
+
+### interchainTransfer
+
+```solidity
+function interchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
+```
+
+Transfer a token interchain.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the tokenId for the token link. |
+| destinationChain | string | the name of the chain to send the token to. |
+| destinationAddress | bytes | the recipient of the interchain transfer. |
+| amount | uint256 | the amount of token to give. |
+| metadata | bytes | the data to be passed to the destination. If provided with a bytes4(0) prefix, it'll execute the destination contract. |
+
+### callContractWithInterchainToken
+
+```solidity
+function callContractWithInterchainToken(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, bytes data) external payable
+```
+
+### transmitInterchainTransfer
+
+```solidity
+function transmitInterchainTransfer(bytes32 tokenId, address sourceAddress, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
+```
+
+Transmit an interchain transfer for the given tokenId. Only callable by a token manager.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the tokenId of the TokenManager (which must be the msg.sender). |
+| sourceAddress | address | the address where the token is coming from, which will also be used for reimbursement of gas. |
+| destinationChain | string | the name of the chain to send tokens to. |
+| destinationAddress | bytes | the destinationAddress for the interchainTransfer. |
+| amount | uint256 | the amount of token to give. |
+| metadata | bytes | the data to be passed to the destination. |
+
+### setFlowLimits
+
+```solidity
+function setFlowLimits(bytes32[] tokenIds, uint256[] flowLimits) external
+```
+
+Used to set a flow limit for a token manager that has the service as its operator.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenIds | bytes32[] | an array of the token Ids of the tokenManagers to set the flow limit of. |
+| flowLimits | uint256[] | the flowLimits to set |
+
+### setTrustedAddress
+
+```solidity
+function setTrustedAddress(string chain, string address_) external
+```
+
+Used to set a trusted address for a chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| chain | string | the chain to set the trusted address of. |
+| address_ | string | the address to set as trusted. |
+
+### removeTrustedAddress
+
+```solidity
+function removeTrustedAddress(string chain) external
+```
+
+Used to remove a trusted address for a chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| chain | string | the chain to set the trusted address of. |
+
+### setPauseStatus
+
+```solidity
+function setPauseStatus(bool paused) external
+```
+
+Allows the owner to pause/unpause the token service.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| paused | bool | whether to pause or unpause. |
+
+### _setup
+
+```solidity
+function _setup(bytes params) internal
+```
+
+### _sanitizeTokenManagerImplementation
+
+```solidity
+function _sanitizeTokenManagerImplementation(address[] tokenManagerImplementations, enum ITokenManagerType.TokenManagerType tokenManagerType) internal pure returns (address implementation_)
+```
+
+### execute
+
+```solidity
+function execute(bytes32 commandId, string sourceChain, string sourceAddress, bytes payload) external
+```
+
+Executes operations based on the payload and messageType.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| commandId | bytes32 |  |
+| sourceChain | string | The chain where the transaction originates from |
+| sourceAddress | string | The address of the remote ITS where the transaction originates from |
+| payload | bytes | The encoded data payload for the transaction |
+
+### contractCallWithTokenValue
+
+```solidity
+function contractCallWithTokenValue(string, string, bytes, string, uint256) public view virtual returns (address, uint256)
+```
+
+### expressExecuteWithToken
+
+```solidity
+function expressExecuteWithToken(bytes32, string, string, bytes, string, uint256) external payable
+```
+
+### executeWithToken
+
+```solidity
+function executeWithToken(bytes32, string, string, bytes, string, uint256) external pure
+```
+
+### _processInterchainTransferPayload
+
+```solidity
+function _processInterchainTransferPayload(address expressExecutor, string sourceChain, bytes payload, uint256 messageType) internal
+```
+
+Processes the payload data for a send token call
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| expressExecutor | address |  |
+| sourceChain | string | The chain where the transaction originates from |
+| payload | bytes | The encoded data payload to be processed |
+| messageType | uint256 |  |
+
+### _processDeployTokenManagerPayload
+
+```solidity
+function _processDeployTokenManagerPayload(bytes payload) internal
+```
+
+Processes a deploy token manager payload.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| payload | bytes | The encoded data payload to be processed |
+
+### _processDeployInterchainTokenPayload
+
+```solidity
+function _processDeployInterchainTokenPayload(bytes payload) internal
+```
+
+Process a deploy interchain token and manager payload.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| payload | bytes | The encoded data payload to be processed |
+
+### _callContract
+
+```solidity
+function _callContract(string destinationChain, bytes payload, uint256 gasValue) internal
+```
+
+Calls a contract on a specific destination chain with the given payload
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| destinationChain | string | The target chain where the contract will be called |
+| payload | bytes | The data payload for the transaction |
+| gasValue | uint256 | The amount of gas to be paid for the transaction |
+
+### _deployRemoteTokenManager
+
+```solidity
+function _deployRemoteTokenManager(bytes32 tokenId, string destinationChain, uint256 gasValue, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params) internal
+```
+
+Deploys a token manager on a destination chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The ID of the token |
+| destinationChain | string | The chain where the token manager will be deployed |
+| gasValue | uint256 | The amount of gas to be paid for the transaction |
+| tokenManagerType | enum ITokenManagerType.TokenManagerType | The type of token manager to be deployed |
+| params | bytes | Additional parameters for the token manager deployment |
+
+### _deployRemoteInterchainToken
+
+```solidity
+function _deployRemoteInterchainToken(bytes32 tokenId, string name, string symbol, uint8 decimals, bytes distributor, string destinationChain, uint256 gasValue) internal
+```
+
+Deploys a interchain token on a destination chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The ID of the token |
+| name | string | The name of the token |
+| symbol | string | The symbol of the token |
+| decimals | uint8 | The number of decimals of the token |
+| distributor | bytes | The distributor address for the token |
+| destinationChain | string | The destination chain where the token will be deployed |
+| gasValue | uint256 | The amount of gas to be paid for the transaction |
+
+### _deployTokenManager
+
+```solidity
+function _deployTokenManager(bytes32 tokenId, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params) internal
+```
+
+Deploys a token manager
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The ID of the token |
+| tokenManagerType | enum ITokenManagerType.TokenManagerType | The type of the token manager to be deployed |
+| params | bytes | Additional parameters for the token manager deployment |
+
+### _getInterchainTokenSalt
+
+```solidity
+function _getInterchainTokenSalt(bytes32 tokenId) internal pure returns (bytes32 salt)
+```
+
+Compute the salt for a interchain token deployment.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The ID of the token |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| salt | bytes32 | The computed salt for the token deployment |
+
+### _deployInterchainToken
+
+```solidity
+function _deployInterchainToken(bytes32 tokenId, bytes distributorBytes, string name, string symbol, uint8 decimals) internal returns (address tokenAddress_)
+```
+
+Deploys a interchain token.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The ID of the token |
+| distributorBytes | bytes | The distributor address for the token |
+| name | string | The name of the token |
+| symbol | string | The symbol of the token |
+| decimals | uint8 | The number of decimals of the token |
+
+### _decodeMetadata
+
+```solidity
+function _decodeMetadata(bytes metadata) internal pure returns (uint32 version, bytes data)
+```
+
+### _transmitInterchainTransfer
+
+```solidity
+function _transmitInterchainTransfer(bytes32 tokenId, address sourceAddress, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) internal
+```
+
+Transmit a callContractWithInterchainToken for the given tokenId. Only callable by a token manager.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | the tokenId of the TokenManager (which must be the msg.sender). |
+| sourceAddress | address | the address where the token is coming from, which will also be used for reimburment of gas. |
+| destinationChain | string | the name of the chain to send tokens to. |
+| destinationAddress | bytes | the destinationAddress for the interchainTransfer. |
+| amount | uint256 | the amount of token to give. |
+| metadata | bytes | the data to be passed to the destination. |
+
+## InterchainTokenExecutable
+
+### NotService
+
+```solidity
+error NotService(address caller)
+```
+
+### interchainTokenService
+
+```solidity
+address interchainTokenService
+```
+
+### EXECUTE_SUCCESS
+
+```solidity
+bytes32 EXECUTE_SUCCESS
+```
+
+### constructor
+
+```solidity
+constructor(address interchainTokenService_) internal
+```
+
+### onlyService
+
+```solidity
+modifier onlyService()
+```
+
+### executeWithInterchainToken
+
+```solidity
+function executeWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) external virtual returns (bytes32)
+```
+
+This will be called after the tokens arrive to this contract
+
+_Executable should revert unless the msg.sender is the InterchainTokenService_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sourceChain | string | the name of the source chain |
+| sourceAddress | bytes | the address that sent the contract call |
+| data | bytes | the data to be processed |
+| tokenId | bytes32 | the tokenId of the token manager managing the token. |
+| token | address | the address of the token. |
+| amount | uint256 | the amount of token that was sent |
+
+### _executeWithInterchainToken
+
+```solidity
+function _executeWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) internal virtual
+```
+
+## InterchainTokenExpressExecutable
+
+### EXPRESS_EXECUTE_SUCCESS
+
+```solidity
+bytes32 EXPRESS_EXECUTE_SUCCESS
+```
+
+### constructor
+
+```solidity
+constructor(address interchainTokenService_) internal
+```
+
+### expressExecuteWithInterchainToken
+
+```solidity
+function expressExecuteWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) external virtual returns (bytes32)
+```
+
+This will be called after the tokens arrive to this contract
+
+_Executable should revert unless the msg.sender is the InterchainTokenService_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sourceChain | string | the name of the source chain |
+| sourceAddress | bytes | the address that sent the contract call |
+| data | bytes | the data to be processed |
+| tokenId | bytes32 | the token id of the token manager managing the token. |
+| token | address | the address of the token. |
+| amount | uint256 | the amount of token that was sent |
+
+## IAddressTracker
+
+### setTrustedAddress
+
+```solidity
+function setTrustedAddress(string chain, string address_) external
+```
+
+_Sets the trusted address for the specified chain_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| chain | string | Chain name to be trusted |
+| address_ | string | Trusted address to be added for the chain |
+
+### removeTrustedAddress
+
+```solidity
+function removeTrustedAddress(string chain) external
+```
+
+_Remove the trusted address of the chain._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| chain | string | Chain name that should be made untrusted |
+
+## IERC20BurnableFrom
+
+_Interface of the ERC20 standard as defined in the EIP._
+
+### burnFrom
+
+```solidity
+function burnFrom(address from, uint256 amount) external
+```
+
+Function to burn tokens
+Requires the caller to have allowance for `amount` on `from`
+
+_Can only be called by the distributor address._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| from | address | The address that will have its tokens burnt |
+| amount | uint256 | The amount of tokens to burn |
+
+## IInterchainTokenDeployer
+
+This contract is used to deploy new instances of the InterchainTokenProxy contract.
+
+### AddressZero
+
+```solidity
+error AddressZero()
+```
+
+### TokenDeploymentFailed
+
+```solidity
+error TokenDeploymentFailed()
+```
+
+### implementationAddress
+
+```solidity
+function implementationAddress() external view returns (address)
+```
+
+Returns the interchain token implementation address
+
+### deployedAddress
+
+```solidity
+function deployedAddress(bytes32 salt) external view returns (address tokenAddress)
+```
+
+Returns the interchain token deployment address.
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenAddress | address | the token address. |
+
+### deployInterchainToken
+
+```solidity
+function deployInterchainToken(bytes32 salt, address tokenManager, address distributor, string name, string symbol, uint8 decimals) external payable returns (address tokenAddress)
+```
+
+Deploys a new instance of the InterchainTokenProxy contract
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| salt | bytes32 | The salt used by Create3Deployer |
+| tokenManager | address | Address of the token manager |
+| distributor | address | Address of the distributor |
+| name | string | Name of the token |
+| symbol | string | Symbol of the token |
+| decimals | uint8 | Decimals of the token |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenAddress | address | Address of the deployed token |
+
+## IInterchainTokenExecutable
+
+Implement this to accept calls from the InterchainTokenService.
+
+### executeWithInterchainToken
+
+```solidity
+function executeWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) external returns (bytes32)
+```
+
+This will be called after the tokens arrive to this contract
+
+_Executable should revert unless the msg.sender is the InterchainTokenService_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sourceChain | string | the name of the source chain |
+| sourceAddress | bytes | the address that sent the contract call |
+| data | bytes | the data to be processed |
+| tokenId | bytes32 | the tokenId of the token manager managing the token. |
+| token | address | the address of the token. |
+| amount | uint256 | the amount of token that was sent |
+
+## IInterchainTokenExpressExecutable
+
+Implement this to accept express calls from the InterchainTokenService.
+
+### expressExecuteWithInterchainToken
+
+```solidity
+function expressExecuteWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) external returns (bytes32)
+```
+
+This will be called after the tokens arrive to this contract
+
+_Executable should revert unless the msg.sender is the InterchainTokenService_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sourceChain | string | the name of the source chain |
+| sourceAddress | bytes | the address that sent the contract call |
+| data | bytes | the data to be processed |
+| tokenId | bytes32 | the token id of the token manager managing the token. |
+| token | address | the address of the token. |
+| amount | uint256 | the amount of token that was sent |
+
+## IInterchainTokenFactory
+
+### ZeroAddress
+
+```solidity
+error ZeroAddress()
+```
+
+### InvalidChainName
+
+```solidity
+error InvalidChainName()
+```
+
+### NotDistributor
+
+```solidity
+error NotDistributor(address distributor)
+```
+
+### NotOperator
+
+```solidity
+error NotOperator(address operator)
+```
+
+### NonZeroMintAmount
+
+```solidity
+error NonZeroMintAmount()
+```
+
+### ApproveFailed
+
+```solidity
+error ApproveFailed()
+```
+
+### chainNameHash
+
+```solidity
+function chainNameHash() external view returns (bytes32)
+```
+
+### interchainTokenSalt
+
+```solidity
+function interchainTokenSalt(bytes32 chainAddressHash_, address deployer, bytes32 salt) external view returns (bytes32)
+```
+
+### interchainTokenId
+
+```solidity
+function interchainTokenId(address deployer, bytes32 salt) external view returns (bytes32 tokenId)
+```
+
+### interchainTokenAddress
+
+```solidity
+function interchainTokenAddress(address deployer, bytes32 salt) external view returns (address tokenAddress)
+```
+
+### deployInterchainToken
+
+```solidity
+function deployInterchainToken(bytes32 salt, string name, string symbol, uint8 decimals, uint256 mintAmount, address distributor) external payable
+```
+
+### deployRemoteInterchainToken
+
+```solidity
+function deployRemoteInterchainToken(string originalChainName, bytes32 salt, address additionalDistributor, string destinationChain, uint256 gasValue) external payable
+```
+
+### canonicalInterchainTokenSalt
+
+```solidity
+function canonicalInterchainTokenSalt(bytes32 chainAddressHash_, address tokenAddress) external view returns (bytes32 salt)
+```
+
+### canonicalInterchainTokenId
+
+```solidity
+function canonicalInterchainTokenId(address tokenAddress) external view returns (bytes32 tokenId)
+```
+
+### registerCanonicalInterchainToken
+
+```solidity
+function registerCanonicalInterchainToken(address tokenAddress) external payable returns (bytes32 tokenId)
+```
+
+### deployRemoteCanonicalInterchainToken
+
+```solidity
+function deployRemoteCanonicalInterchainToken(string originalChainName, address originalAddress, string destinationChain, uint256 gasValue) external payable
+```
+
+### interchainTransfer
+
+```solidity
+function interchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, uint256 gasValue) external payable
+```
+
+### tokenTransferFrom
+
+```solidity
+function tokenTransferFrom(bytes32 tokenId, uint256 amount) external payable
+```
+
+### tokenApprove
+
+```solidity
+function tokenApprove(bytes32 tokenId, uint256 amount) external payable
+```
+
+## IInterchainTokenService
+
+### InvalidTokenManagerImplementationType
+
+```solidity
+error InvalidTokenManagerImplementationType(address implementation)
+```
+
+### InvalidChainName
+
+```solidity
+error InvalidChainName()
+```
+
+### NotRemoteService
+
+```solidity
+error NotRemoteService()
+```
+
+### TokenManagerDoesNotExist
+
+```solidity
+error TokenManagerDoesNotExist(bytes32 tokenId)
+```
+
+### NotTokenManager
+
+```solidity
+error NotTokenManager(address caller, address tokenManager)
+```
+
+### ExecuteWithInterchainTokenFailed
+
+```solidity
+error ExecuteWithInterchainTokenFailed(address contractAddress)
+```
+
+### ExpressExecuteWithInterchainTokenFailed
+
+```solidity
+error ExpressExecuteWithInterchainTokenFailed(address contractAddress)
+```
+
+### GatewayToken
+
+```solidity
+error GatewayToken()
+```
+
+### TokenManagerDeploymentFailed
+
+```solidity
+error TokenManagerDeploymentFailed(bytes error)
+```
+
+### InterchainTokenDeploymentFailed
+
+```solidity
+error InterchainTokenDeploymentFailed(bytes error)
+```
+
+### InvalidMessageType
+
+```solidity
+error InvalidMessageType(uint256 messageType)
+```
+
+### InvalidMetadataVersion
+
+```solidity
+error InvalidMetadataVersion(uint32 version)
+```
+
+### ExecuteWithTokenNotSupported
+
+```solidity
+error ExecuteWithTokenNotSupported()
+```
+
+### InvalidExpressMessageType
+
+```solidity
+error InvalidExpressMessageType(uint256 messageType)
+```
+
+### InterchainTransfer
+
+```solidity
+event InterchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount)
+```
+
+### InterchainTransferWithData
+
+```solidity
+event InterchainTransferWithData(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, address sourceAddress, bytes data)
+```
+
+### InterchainTransferReceived
+
+```solidity
+event InterchainTransferReceived(bytes32 tokenId, string sourceChain, bytes sourceAddress, address destinationAddress, uint256 amount)
+```
+
+### InterchainTransferReceivedWithData
+
+```solidity
+event InterchainTransferReceivedWithData(bytes32 tokenId, string sourceChain, bytes sourceAddress, address destinationAddress, uint256 amount)
+```
+
+### TokenManagerDeploymentStarted
+
+```solidity
+event TokenManagerDeploymentStarted(bytes32 tokenId, string destinationChain, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params)
+```
+
+### InterchainTokenDeploymentStarted
+
+```solidity
+event InterchainTokenDeploymentStarted(bytes32 tokenId, string tokenName, string tokenSymbol, uint8 tokenDecimals, bytes distributor, string destinationChain)
+```
+
+### TokenManagerDeployed
+
+```solidity
+event TokenManagerDeployed(bytes32 tokenId, address tokenManager, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params)
+```
+
+### InterchainTokenDeployed
+
+```solidity
+event InterchainTokenDeployed(bytes32 tokenId, address tokenAddress, address distributor, string name, string symbol, uint8 decimals)
+```
+
+### InterchainTokenIdClaimed
+
+```solidity
+event InterchainTokenIdClaimed(bytes32 tokenId, address deployer, bytes32 salt)
+```
+
+### tokenManagerDeployer
+
+```solidity
+function tokenManagerDeployer() external view returns (address tokenManagerDeployerAddress)
+```
+
+Returns the address of the token manager deployer contract.
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManagerDeployerAddress | address | The address of the token manager deployer contract. |
+
+### interchainTokenDeployer
+
+```solidity
+function interchainTokenDeployer() external view returns (address interchainTokenDeployerAddress)
+```
+
+Returns the address of the interchain token deployer contract.
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| interchainTokenDeployerAddress | address | The address of the interchain token deployer contract. |
+
+### chainNameHash
+
+```solidity
+function chainNameHash() external view returns (bytes32)
+```
+
+Returns hash of the chain name.
+
+### tokenManagerAddress
+
+```solidity
+function tokenManagerAddress(bytes32 tokenId) external view returns (address tokenManagerAddress_)
+```
+
+Returns the address of the token manager associated with the given tokenId.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The tokenId of the token manager. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManagerAddress_ | address | The address of the token manager. |
+
+### validTokenManagerAddress
+
+```solidity
+function validTokenManagerAddress(bytes32 tokenId) external view returns (address tokenManagerAddress_)
+```
+
+Returns the address of the valid token manager associated with the given tokenId.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The tokenId of the token manager. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManagerAddress_ | address | The address of the valid token manager. |
+
+### tokenAddress
+
+```solidity
+function tokenAddress(bytes32 tokenId) external view returns (address tokenAddress_)
+```
+
+Returns the address of the token associated with the given tokenId.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The tokenId of the token manager. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenAddress_ | address | The address of the token. |
+
+### interchainTokenAddress
+
+```solidity
+function interchainTokenAddress(bytes32 tokenId) external view returns (address tokenAddress_)
+```
+
+Returns the address of the interchain token associated with the given tokenId.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The tokenId of the interchain token. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenAddress_ | address | The address of the interchain token. |
+
+### interchainTokenId
+
+```solidity
+function interchainTokenId(address operator_, bytes32 salt) external view returns (bytes32 tokenId)
+```
+
+Returns the custom tokenId associated with the given operator and salt.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| operator_ | address | The operator address. |
+| salt | bytes32 | The salt used for token id calculation. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The custom tokenId associated with the operator and salt. |
+
+### deployTokenManager
+
+```solidity
+function deployTokenManager(bytes32 salt, string destinationChain, enum ITokenManagerType.TokenManagerType tokenManagerType, bytes params, uint256 gasValue) external payable returns (bytes32 tokenId)
+```
+
+Deploys a custom token manager contract on a remote chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| salt | bytes32 | The salt used for token manager deployment. |
+| destinationChain | string | The name of the destination chain. |
+| tokenManagerType | enum ITokenManagerType.TokenManagerType | The type of token manager. |
+| params | bytes | The deployment parameters. |
+| gasValue | uint256 | The gas value for deployment. |
+
+### deployInterchainToken
+
+```solidity
+function deployInterchainToken(bytes32 salt, string destinationChain, string name, string symbol, uint8 decimals, bytes distributor, uint256 gasValue) external payable
+```
+
+Deploys and registers a interchain token on a remote chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| salt | bytes32 | The salt used for token deployment. |
+| destinationChain | string | The name of the destination chain. Use '' for this chain. |
+| name | string | The name of the interchain tokens. |
+| symbol | string | The symbol of the interchain tokens. |
+| decimals | uint8 | The number of decimals for the interchain tokens. |
+| distributor | bytes | The distributor data for mint/burn operations. |
+| gasValue | uint256 | The gas value for deployment. |
+
+### interchainTransfer
+
+```solidity
+function interchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
+```
+
+### callContractWithInterchainToken
+
+```solidity
+function callContractWithInterchainToken(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, bytes data) external payable
+```
+
+### transmitInterchainTransfer
+
+```solidity
+function transmitInterchainTransfer(bytes32 tokenId, address sourceAddress, string destinationChain, bytes destinationAddress, uint256 amount, bytes metadata) external payable
+```
+
+Initiates an interchain token transfer. Only callable by TokenManagers
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The tokenId of the token to be transmitted. |
+| sourceAddress | address | The source address of the token. |
+| destinationChain | string | The name of the destination chain. |
+| destinationAddress | bytes | The destination address on the destination chain. |
+| amount | uint256 | The amount of tokens to transmit. |
+| metadata | bytes | The metadata associated with the transmission. |
+
+### setFlowLimits
+
+```solidity
+function setFlowLimits(bytes32[] tokenIds, uint256[] flowLimits) external
+```
+
+Sets the flow limits for multiple tokens.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenIds | bytes32[] | An array of tokenIds. |
+| flowLimits | uint256[] | An array of flow limits corresponding to the tokenIds. |
+
+### flowLimit
+
+```solidity
+function flowLimit(bytes32 tokenId) external view returns (uint256 flowLimit_)
+```
+
+Returns the flow limit for a specific token.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The tokenId of the token. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowLimit_ | uint256 | The flow limit for the token. |
+
+### flowOutAmount
+
+```solidity
+function flowOutAmount(bytes32 tokenId) external view returns (uint256 flowOutAmount_)
+```
+
+Returns the total amount of outgoing flow for a specific token.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The tokenId of the token. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowOutAmount_ | uint256 | The total amount of outgoing flow for the token. |
+
+### flowInAmount
+
+```solidity
+function flowInAmount(bytes32 tokenId) external view returns (uint256 flowInAmount_)
+```
+
+Returns the total amount of incoming flow for a specific token.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The tokenId of the token. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowInAmount_ | uint256 | The total amount of incoming flow for the token. |
+
+### setPauseStatus
+
+```solidity
+function setPauseStatus(bool paused) external
+```
+
+Allows the owner to pause/unpause the token service.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| paused | bool | whether to pause or unpause. |
+
+## ITokenManagerDeployer
+
+This contract is used to deploy new instances of the TokenManagerProxy contract.
+
+### AddressZero
+
+```solidity
+error AddressZero()
+```
+
+### TokenManagerDeploymentFailed
+
+```solidity
+error TokenManagerDeploymentFailed()
+```
+
+### deployTokenManager
+
+```solidity
+function deployTokenManager(bytes32 tokenId, uint256 implementationType, bytes params) external payable returns (address tokenManager)
+```
+
+Deploys a new instance of the TokenManagerProxy contract
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | bytes32 | The unique identifier for the token |
+| implementationType | uint256 | Token manager implementation type |
+| params | bytes | Additional parameters used in the setup of the token manager |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManager | address | Address of the deployed tokenManager |
+
+## ITokenManagerImplementation
+
+### tokenManagerImplementation
+
+```solidity
+function tokenManagerImplementation(uint256 tokenManagerType) external view returns (address tokenManagerAddress_)
+```
+
+Returns the implementation address for a given token manager type.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManagerType | uint256 | The type of token manager. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenManagerAddress_ | address | The address of the token manager implementation. |
+
+## ITokenManagerLiquidityPool
+
+This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
+
+### params
+
+```solidity
+function params(bytes operator_, address tokenAddress_, address liquidityPool_) external pure returns (bytes params_)
+```
+
+Getter function for the parameters of a lock/unlock TokenManager. Mainly to be used by frontends.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| operator_ | bytes | the operator of the TokenManager. |
+| tokenAddress_ | address | the token to be managed. |
+| liquidityPool_ | address | he address of the liquidity pool. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| params_ | bytes | the resulting params to be passed to custom TokenManager deployments. |
+
+### liquidityPool
+
+```solidity
+function liquidityPool() external view returns (address liquidityPool_)
+```
+
+_Reads the stored liquidity pool address from the specified storage slot_
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| liquidityPool_ | address | The address of the liquidity pool |
+
+### setLiquidityPool
+
+```solidity
+function setLiquidityPool(address newLiquidityPool) external
+```
+
+_Updates the address of the liquidity pool. Can only be called by the operator._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| newLiquidityPool | address | The new address of the liquidity pool |
+
+## ITokenManagerLockUnlock
+
+This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
+
+### params
+
+```solidity
+function params(bytes operator_, address tokenAddress_) external pure returns (bytes params_)
+```
+
+Getter function for the parameters of a lock/unlock TokenManager. Mainly to be used by frontends.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| operator_ | bytes | the operator of the TokenManager. |
+| tokenAddress_ | address | the token to be managed. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| params_ | bytes | the resulting params to be passed to custom TokenManager deployments. |
+
+## ITokenManagerLockUnlockFee
+
+This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
+
+### params
+
+```solidity
+function params(bytes operator_, address tokenAddress_) external pure returns (bytes params_)
+```
+
+Getter function for the parameters of a lock/unlock TokenManager. Mainly to be used by frontends.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| operator_ | bytes | the operator of the TokenManager. |
+| tokenAddress_ | address | the token to be managed. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| params_ | bytes | the resulting params to be passed to custom TokenManager deployments. |
+
+## ITokenManagerMintBurn
+
+This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
+
+### params
+
+```solidity
+function params(bytes operator_, address tokenAddress_) external pure returns (bytes params_)
+```
+
+Getter function for the parameters of a lock/unlock TokenManager. Mainly to be used by frontends.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| operator_ | bytes | the operator of the TokenManager. |
+| tokenAddress_ | address | the token to be managed. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| params_ | bytes | the resulting params to be passed to custom TokenManager deployments. |
+
+## ITokenManagerProxy
+
+_This interface is implemented by the token manager proxy contract._
+
+### ZeroAddress
+
+```solidity
+error ZeroAddress()
+```
+
+### implementationType
+
+```solidity
+function implementationType() external view returns (uint256)
+```
+
+Returns implementation type of this token manager
+
+### interchainTokenId
+
+```solidity
+function interchainTokenId() external view returns (bytes32)
+```
+
+Returns token ID of the token manager.
+
+## InterchainTokenFactoryProxy
+
+_Proxy contract for interchain token service contracts. Inherits from the Proxy contract._
+
+### constructor
+
+```solidity
+constructor(address implementationAddress, address owner) public
+```
+
+_Constructs the InterchainTokenServiceProxy contract._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| implementationAddress | address | Address of the interchain token service implementation |
+| owner | address | Address of the owner of the proxy |
+
+### contractId
+
+```solidity
+function contractId() internal pure returns (bytes32)
+```
+
+_Override for the 'contractId' function in FinalProxy. Returns a unique identifier for this contract._
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bytes32 | bytes32 identifier for this contract |
+
+## InterchainTokenProxy
+
+_Proxy contract for InterchainToken contracts. Inherits from FixedProxy._
+
+### constructor
+
+```solidity
+constructor(address implementationAddress, bytes params) public
+```
+
+_Constructs the InterchainTokenProxy contract._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| implementationAddress | address | Address of the InterchainToken implementation |
+| params | bytes | Initialization parameters for the InterchainToken contract |
+
+### contractId
+
+```solidity
+function contractId() internal pure returns (bytes32)
+```
+
+Getter for the contract id.
+
+## InterchainTokenServiceProxy
+
+_Proxy contract for interchain token service contracts. Inherits from the FinalProxy contract._
+
+### constructor
+
+```solidity
+constructor(address implementationAddress, address owner, bytes setupParams) public
+```
+
+_Constructs the InterchainTokenServiceProxy contract._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| implementationAddress | address | Address of the interchain token service implementation |
+| owner | address | Address of the owner of the proxy |
+| setupParams | bytes |  |
+
+### contractId
+
+```solidity
+function contractId() internal pure returns (bytes32)
+```
+
+_Override for the 'contractId' function in FinalProxy. Returns a unique identifier for this contract._
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bytes32 | bytes32 identifier for this contract |
+
+## TokenManagerProxy
+
+This contract is a proxy for token manager contracts.
+
+_It implements ITokenManagerProxy._
+
+### interchainTokenService
+
+```solidity
+address interchainTokenService
+```
+
+### implementationType
+
+```solidity
+uint256 implementationType
+```
+
+Returns implementation type of this token manager
+
+### interchainTokenId
+
+```solidity
+bytes32 interchainTokenId
+```
+
+Returns token ID of the token manager.
+
+### constructor
+
+```solidity
+constructor(address interchainTokenService_, uint256 implementationType_, bytes32 tokenId, bytes params) public
+```
+
+_Constructs the TokenManagerProxy contract._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| interchainTokenService_ | address | The address of the interchain token service |
+| implementationType_ | uint256 | The token manager type |
+| tokenId | bytes32 | The identifier for the token |
+| params | bytes | The initialization parameters for the token manager contract |
+
+### contractId
+
+```solidity
+function contractId() internal pure returns (bytes32)
+```
+
+_Returns the contract ID._
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bytes32 | bytes32 The contract ID |
+
+### implementation
+
+```solidity
+function implementation() public view returns (address implementation_)
+```
+
+_Returns the address of the current implementation._
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| implementation_ | address | The address of the current implementation |
+
+### _tokenManagerImplementation
+
+```solidity
+function _tokenManagerImplementation(address interchainTokenService_, uint256 implementationType_) internal view returns (address implementation_)
+```
+
+_Returns the implementation address from the interchain token service for the provided type._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| interchainTokenService_ | address | The address of the interchain token service |
+| implementationType_ | uint256 | The token manager type |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| implementation_ | address | The address of the implementation |
+
+## FeeOnTransferTokenTest
+
+### tokenManager_
+
+```solidity
+address tokenManager_
+```
+
+### tokenManagerRequiresApproval_
+
+```solidity
+bool tokenManagerRequiresApproval_
+```
+
+### name
+
+```solidity
+string name
+```
+
+### symbol
+
+```solidity
+string symbol
+```
+
+### decimals
+
+```solidity
+uint8 decimals
+```
+
+### constructor
+
+```solidity
+constructor(string name_, string symbol_, uint8 decimals_, address tokenManagerAddress) public
+```
+
+### tokenManager
+
+```solidity
+function tokenManager() public view returns (address)
+```
+
+Getter for the tokenManager used for this token.
+
+_Needs to be overwritten._
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | address |  |
+
+### _beforeInterchainTransfer
+
+```solidity
+function _beforeInterchainTransfer(address sender, string, bytes, uint256 amount, bytes) internal
+```
+
+### setTokenManagerRequiresApproval
+
+```solidity
+function setTokenManagerRequiresApproval(bool requiresApproval) public
+```
+
+### mint
+
+```solidity
+function mint(address account, uint256 amount) external
+```
+
+### burn
+
+```solidity
+function burn(address account, uint256 amount) external
+```
+
+### setTokenManager
+
+```solidity
+function setTokenManager(address tokenManagerAddress) external
+```
+
+### _transfer
+
+```solidity
+function _transfer(address sender, address recipient, uint256 amount) internal
+```
+
+_Moves tokens `amount` from `sender` to `recipient`.
+
+This is internal function is equivalent to {transfer}, and can be used to
+e.g. implement automatic token fees, slashing mechanisms, etc.
+
+Emits a {Transfer} event.
+
+Requirements:
+
+- `sender` cannot be the zero address.
+- `recipient` cannot be the zero address.
+- `sender` must have a balance of at least `amount`._
+
+## Invalid
+
+```solidity
+error Invalid()
+```
+
+## TestTokenManager
+
+### NAME
+
+```solidity
+string NAME
+```
+
+### constructor
+
+```solidity
+constructor(address interchainTokenService_) public
+```
+
+## TestDistributable
+
+### NAME
+
+```solidity
+string NAME
+```
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+## TestFlowLimit
+
+### NAME
+
+```solidity
+string NAME
+```
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+## TestOperatable
+
+### NAME
+
+```solidity
+string NAME
+```
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+## InterchainExecutableTest
+
+### MessageReceived
+
+```solidity
+event MessageReceived(string sourceChain, bytes sourceAddress, address receiver, string message, bytes32 tokenId, uint256 amount)
+```
+
+### constructor
+
+```solidity
+constructor(address interchainTokenService_) public
+```
+
+### lastMessage
+
+```solidity
+string lastMessage
+```
+
+### _executeWithInterchainToken
+
+```solidity
+function _executeWithInterchainToken(string sourceChain, bytes sourceAddress, bytes data, bytes32 tokenId, address token, uint256 amount) internal
+```
+
+## InterchainTokenTest
+
+### tokenManager_
+
+```solidity
+address tokenManager_
+```
+
+### tokenManagerRequiresApproval_
+
+```solidity
+bool tokenManagerRequiresApproval_
+```
+
+### name
+
+```solidity
+string name
+```
+
+### symbol
+
+```solidity
+string symbol
+```
+
+### decimals
+
+```solidity
+uint8 decimals
+```
+
+### constructor
+
+```solidity
+constructor(string name_, string symbol_, uint8 decimals_, address tokenManagerAddress) public
+```
+
+### tokenManager
+
+```solidity
+function tokenManager() public view returns (address)
+```
+
+Getter for the tokenManager used for this token.
+
+_Needs to be overwritten._
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | address |  |
+
+### _beforeInterchainTransfer
+
+```solidity
+function _beforeInterchainTransfer(address sender, string, bytes, uint256 amount, bytes) internal
+```
+
+### setTokenManagerRequiresApproval
+
+```solidity
+function setTokenManagerRequiresApproval(bool requiresApproval) public
+```
+
+### mint
+
+```solidity
+function mint(address account, uint256 amount) external
+```
+
+### burn
+
+```solidity
+function burn(address account, uint256 amount) external
+```
+
+### setTokenManager
+
+```solidity
+function setTokenManager(address tokenManagerAddress) external
+```
+
+## DistributableTest
+
+### nonce
+
+```solidity
+uint256 nonce
+```
+
+### constructor
+
+```solidity
+constructor(address distributor) public
+```
+
+### testDistributable
+
+```solidity
+function testDistributable() external
+```
+
+### distributorRole
+
+```solidity
+function distributorRole() external pure returns (uint8)
+```
+
+## FlowLimitTest
+
+### TOKEN_ID
+
+```solidity
+bytes32 TOKEN_ID
+```
+
+### setFlowLimit
+
+```solidity
+function setFlowLimit(uint256 flowLimit) external
+```
+
+### addFlowIn
+
+```solidity
+function addFlowIn(uint256 flowInAmount) external
+```
+
+### addFlowOut
+
+```solidity
+function addFlowOut(uint256 flowOutAmount) external
+```
+
+## FlowLimitTestLiveNetwork
+
+### FLOW_LIMIT_SLOT
+
+```solidity
+uint256 FLOW_LIMIT_SLOT
+```
+
+### PREFIX_FLOW_OUT_AMOUNT
+
+```solidity
+uint256 PREFIX_FLOW_OUT_AMOUNT
+```
+
+### PREFIX_FLOW_IN_AMOUNT
+
+```solidity
+uint256 PREFIX_FLOW_IN_AMOUNT
+```
+
+### TOKEN_ID
+
+```solidity
+bytes32 TOKEN_ID
+```
+
+### EPOCH_TIME
+
+```solidity
+uint256 EPOCH_TIME
+```
+
+### flowLimit
+
+```solidity
+function flowLimit() public view returns (uint256 flowLimit_)
+```
+
+Returns the current flow limit
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowLimit_ | uint256 | The current flow limit value |
+
+### _setFlowLimit
+
+```solidity
+function _setFlowLimit(uint256 flowLimit_) internal
+```
+
+### _getFlowOutSlot
+
+```solidity
+function _getFlowOutSlot(uint256 epoch) internal pure returns (uint256 slot)
+```
+
+### _getFlowInSlot
+
+```solidity
+function _getFlowInSlot(uint256 epoch) internal pure returns (uint256 slot)
+```
+
+### flowOutAmount
+
+```solidity
+function flowOutAmount() external view returns (uint256 flowOutAmount_)
+```
+
+Returns the current flow out amount
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowOutAmount_ | uint256 | The current flow out amount |
+
+### flowInAmount
+
+```solidity
+function flowInAmount() external view returns (uint256 flowInAmount_)
+```
+
+Returns the current flow in amount
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| flowInAmount_ | uint256 | The current flow in amount |
+
+### _addFlow
+
+```solidity
+function _addFlow(uint256 flowLimit_, uint256 slotToAdd, uint256 slotToCompare, uint256 flowAmount) internal
+```
+
+### _addFlowOut
+
+```solidity
+function _addFlowOut(uint256 flowOutAmount_) internal
+```
+
+### _addFlowIn
+
+```solidity
+function _addFlowIn(uint256 flowInAmount_) internal
+```
+
+### setFlowLimit
+
+```solidity
+function setFlowLimit(uint256 flowLimit_) external
+```
+
+### addFlowIn
+
+```solidity
+function addFlowIn(uint256 flowInAmount_) external
+```
+
+### addFlowOut
+
+```solidity
+function addFlowOut(uint256 flowOutAmount_) external
+```
+
+## NakedProxy
+
+### implementation
+
+```solidity
+address implementation
+```
+
+### constructor
+
+```solidity
+constructor(address implementation_) public
+```
+
+### fallback
+
+```solidity
+fallback() external payable virtual
+```
+
+### receive
+
+```solidity
+receive() external payable virtual
+```
+
+## OperatorableTest
+
+### nonce
+
+```solidity
+uint256 nonce
+```
+
+### constructor
+
+```solidity
+constructor(address operator) public
+```
+
+### testOperatorable
+
+```solidity
+function testOperatorable() external
+```
+
+### operatorRole
+
+```solidity
+function operatorRole() external pure returns (uint8)
+```
+
 ## TokenManager
 
 This contract is responsible for handling tokens before initiating a cross chain token transfer, or after receiving one.
@@ -4020,6 +3862,14 @@ modifier onlyToken()
 ```
 
 _A modifier that allows only the token to execute the function._
+
+### contractId
+
+```solidity
+function contractId() external pure returns (bytes32)
+```
+
+Getter for the contract id.
 
 ### tokenAddress
 
@@ -4803,200 +4653,6 @@ _Burns the specified amount of tokens from a particular address._
 | ---- | ---- | ----------- |
 | [0] | uint256 | uint Amount of tokens burned |
 
-## TokenFactory
-
-### NotApproved
-
-```solidity
-error NotApproved(address tokenAddress)
-```
-
-### service
-
-```solidity
-contract IInterchainTokenService service
-```
-
-### chainNameHash
-
-```solidity
-bytes32 chainNameHash
-```
-
-### PREFIX_CANONICAL_TOKEN_SALT
-
-```solidity
-bytes32 PREFIX_CANONICAL_TOKEN_SALT
-```
-
-### PREFIX_INTERCHAIN_TOKEN_SALT
-
-```solidity
-bytes32 PREFIX_INTERCHAIN_TOKEN_SALT
-```
-
-### constructor
-
-```solidity
-constructor(address interchainTokenServiceAddress) public
-```
-
-### contractId
-
-```solidity
-function contractId() external pure returns (bytes32)
-```
-
-Getter for the contract id.
-
-### interchainTokenSalt
-
-```solidity
-function interchainTokenSalt(bytes32 chainNameHash_, address deployer, bytes32 salt) public pure returns (bytes32)
-```
-
-### interchainTokenId
-
-```solidity
-function interchainTokenId(address deployer, bytes32 salt) public view returns (bytes32 tokenId)
-```
-
-### interchainTokenAddress
-
-```solidity
-function interchainTokenAddress(address deployer, bytes32 salt) public view returns (address tokenAddress)
-```
-
-### deployInterchainToken
-
-```solidity
-function deployInterchainToken(bytes32 salt, string name, string symbol, uint8 decimals, uint256 mintAmount, address distributor, address operator) external payable
-```
-
-### deployRemoteInterchainToken
-
-```solidity
-function deployRemoteInterchainToken(string originalChainName, bytes32 salt, address additionalDistributor, address optionalOperator, string destinationChain, uint256 gasValue) external payable
-```
-
-### _deployInterchainToken
-
-```solidity
-function _deployInterchainToken(bytes32 salt, string destinationChain, string tokenName, string tokenSymbol, uint8 tokenDecimals, bytes distributor, bytes operator, uint256 gasValue) internal
-```
-
-### canonicalInterchainTokenSalt
-
-```solidity
-function canonicalInterchainTokenSalt(bytes32 chainNameHash_, address tokenAddress) public pure returns (bytes32 salt)
-```
-
-### canonicalInterchainTokenId
-
-```solidity
-function canonicalInterchainTokenId(address tokenAddress) public view returns (bytes32 tokenId)
-```
-
-### registerCanonicalInterchainToken
-
-```solidity
-function registerCanonicalInterchainToken(address tokenAddress) external payable returns (bytes32 tokenId)
-```
-
-### deployRemoteCanonicalInterchainToken
-
-```solidity
-function deployRemoteCanonicalInterchainToken(string originalChain, address originalTokenAddress, string destinationChain, uint256 gasValue) external payable
-```
-
-### interchainTransfer
-
-```solidity
-function interchainTransfer(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, uint256 gasValue) external payable
-```
-
-### interchainTransferFrom
-
-```solidity
-function interchainTransferFrom(bytes32 tokenId, string destinationChain, bytes destinationAddress, uint256 amount, uint256 gasValue) external payable
-```
-
-## Distributable
-
-_A contract module which provides a basic access control mechanism, where
-there is an account (a distributor) that can be granted exclusive access to
-specific functions. This module is used through inheritance._
-
-### _addDistributor
-
-```solidity
-function _addDistributor(address distributor_) internal
-```
-
-_Internal function that stores the new distributor address in the correct storage slot_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| distributor_ | address | The address of the new distributor |
-
-### transferDistributorship
-
-```solidity
-function transferDistributorship(address distributor_) external
-```
-
-Change the distributor of the contract
-
-_Can only be called by the current distributor_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| distributor_ | address | The address of the new distributor |
-
-### proposeDistributorship
-
-```solidity
-function proposeDistributorship(address distributor_) external
-```
-
-Proposed a change of the distributor of the contract
-
-_Can only be called by the current distributor_
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| distributor_ | address | The address of the new distributor |
-
-### acceptDistributorship
-
-```solidity
-function acceptDistributorship(address fromDistributor) external
-```
-
-Accept a change of the distributor of the contract
-
-_Can only be called by the proposed distributor_
-
-### isDistributor
-
-```solidity
-function isDistributor(address addr) external view returns (bool)
-```
-
-Query if an address is a distributor
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| addr | address | the address to query for |
-
 ## FlowLimit
 
 Implements flow limit logic for interchain token transfers.
@@ -5169,29 +4825,6 @@ _Adds a flow in amount_
 | ---- | ---- | ----------- |
 | flowInAmount_ | uint256 | The flow in amount to add |
 
-## Implementation
-
-This contract serves as a base for other contracts and enforces a proxy-first access restriction.
-
-_Derived contracts must implement the setup function._
-
-### constructor
-
-```solidity
-constructor() internal
-```
-
-_Contract constructor that sets the implementation address to the address of this contract._
-
-### onlyProxy
-
-```solidity
-modifier onlyProxy()
-```
-
-_Modifier to require the caller to be the proxy contract.
-Reverts if the caller is the current contract (i.e., the implementation contract itself)._
-
 ## InterchainTokenDeployer
 
 This contract is used to deploy new instances of the InterchainTokenProxy contract.
@@ -5266,7 +4899,7 @@ specific functions. This module is used through inheritance._
 ### _addOperator
 
 ```solidity
-function _addOperator(address operator_) internal
+function _addOperator(address operator) internal
 ```
 
 _Internal function that stores the new operator address in the correct storage slot_
@@ -5275,12 +4908,12 @@ _Internal function that stores the new operator address in the correct storage s
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| operator_ | address | The address of the new operator |
+| operator | address | The address of the new operator |
 
 ### transferOperatorship
 
 ```solidity
-function transferOperatorship(address operator_) external
+function transferOperatorship(address operator) external
 ```
 
 Change the operator of the contract
@@ -5291,12 +4924,12 @@ _Can only be called by the current operator_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| operator_ | address | The address of the new operator |
+| operator | address | The address of the new operator |
 
 ### proposeOperatorship
 
 ```solidity
-function proposeOperatorship(address operator_) external
+function proposeOperatorship(address operator) external
 ```
 
 Proposed a change of the operator of the contract
@@ -5307,7 +4940,7 @@ _Can only be called by the current operator_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| operator_ | address | The address of the new operator |
+| operator | address | The address of the new operator |
 
 ### acceptOperatorship
 
@@ -5332,18 +4965,6 @@ Query if an address is an operator
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | addr | address | the address to query for |
-
-## RolesConstants
-
-### Roles
-
-```solidity
-enum Roles {
-  DISTRIBUTOR,
-  OPERATOR,
-  FLOW_LIMITER
-}
-```
 
 ## TokenManagerDeployer
 


### PR DESCRIPTION
Use `IInterchainTokenStandard` naming convention