### PR TITLE
feat: flow limit exceeded error

### DIFF
--- a/contracts/interfaces/IFlowLimit.sol
+++ b/contracts/interfaces/IFlowLimit.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.0;
  * @notice Interface for flow limit logic for interchain token transfers.
  */
 interface IFlowLimit {
-    error FlowLimitExceeded(uint256 limit, uint256 flowAmount);
+    error FlowLimitExceeded(uint256 limit, uint256 flowAmount, address tokenManager);
 
     event FlowLimitSet(bytes32 indexed tokenId, address operator, uint256 flowLimit_);
 

--- a/contracts/test/utils/TestFlowLimitLiveNetwork.sol
+++ b/contracts/test/utils/TestFlowLimitLiveNetwork.sol
@@ -63,8 +63,8 @@ contract TestFlowLimitLiveNetwork is IFlowLimit {
 
         uint256 maxFlowLimit = flowToCompare + flowLimit_;
         uint256 netFlowAmount = flowToAdd + flowAmount;
-        if (netFlowAmount > maxFlowLimit) revert FlowLimitExceeded(maxFlowLimit, netFlowAmount);
-        if (flowAmount > flowLimit_) revert FlowLimitExceeded(flowLimit_, flowAmount);
+        if (netFlowAmount > maxFlowLimit) revert FlowLimitExceeded(maxFlowLimit, netFlowAmount, address(this));
+        if (flowAmount > flowLimit_) revert FlowLimitExceeded(flowLimit_, flowAmount, address(this));
 
         assembly {
             sstore(slotToAdd, add(flowToAdd, flowAmount))

--- a/contracts/utils/FlowLimit.sol
+++ b/contracts/utils/FlowLimit.sol
@@ -101,8 +101,8 @@ contract FlowLimit is IFlowLimit {
         }
 
         if (flowToAdd + flowAmount > flowToCompare + flowLimit_)
-            revert FlowLimitExceeded((flowToCompare + flowLimit_), flowToAdd + flowAmount);
-        if (flowAmount > flowLimit_) revert FlowLimitExceeded(flowLimit_, flowAmount);
+            revert FlowLimitExceeded((flowToCompare + flowLimit_), flowToAdd + flowAmount, address(this));
+        if (flowAmount > flowLimit_) revert FlowLimitExceeded(flowLimit_, flowAmount, address(this));
 
         assembly {
             sstore(slotToAdd, add(flowToAdd, flowAmount))

--- a/docs/index.md
+++ b/docs/index.md
@@ -1631,7 +1631,7 @@ Getter for the decimals of the token
 ### FlowLimitExceeded
 
 ```solidity
-error FlowLimitExceeded(uint256 limit, uint256 flowAmount)
+error FlowLimitExceeded(uint256 limit, uint256 flowAmount, address tokenManager)
 ```
 
 ### FlowLimitSet

--- a/test/TokenService.js
+++ b/test/TokenService.js
@@ -2253,7 +2253,7 @@ describe('Interchain Token Service', () => {
                 (gasOptions) => tokenManager.interchainTransfer(destinationChain, destinationAddress, sendAmount, '0x', gasOptions),
                 tokenManager,
                 'FlowLimitExceeded',
-                [flowLimit, 2 * sendAmount],
+                [flowLimit, 2 * sendAmount, tokenManager.address],
             );
         });
 
@@ -2288,6 +2288,7 @@ describe('Interchain Token Service', () => {
             await expectRevert((gasOptions) => receiveToken(sendAmount, gasOptions), tokenManager, 'FlowLimitExceeded', [
                 flowLimit,
                 2 * sendAmount,
+                tokenManager.address,
             ]);
         });
 

--- a/test/UtilsTest.js
+++ b/test/UtilsTest.js
@@ -208,7 +208,11 @@ describe('FlowLimit', async () => {
             expect(await test.flowInAmount()).to.equal(i + 1);
         }
 
-        await expectRevert((gasOptions) => test.addFlowIn(1, gasOptions), test, 'FlowLimitExceeded', [flowLimit, flowLimit + 1]);
+        await expectRevert((gasOptions) => test.addFlowIn(1, gasOptions), test, 'FlowLimitExceeded', [
+            flowLimit,
+            flowLimit + 1,
+            test.address,
+        ]);
 
         await nextEpoch();
 
@@ -225,7 +229,11 @@ describe('FlowLimit', async () => {
             expect(await test.flowOutAmount()).to.equal(i + 1);
         }
 
-        await expectRevert((gasOptions) => test.addFlowOut(1, gasOptions), test, 'FlowLimitExceeded', [flowLimit, flowLimit + 1]);
+        await expectRevert((gasOptions) => test.addFlowOut(1, gasOptions), test, 'FlowLimitExceeded', [
+            flowLimit,
+            flowLimit + 1,
+            test.address,
+        ]);
 
         await nextEpoch();
 
@@ -243,6 +251,7 @@ describe('FlowLimit', async () => {
         await expectRevert((gasOptions) => test.addFlowIn(excessiveFlowAmount, gasOptions), test, 'FlowLimitExceeded', [
             flowLimit,
             excessiveFlowAmount,
+            test.address,
         ]);
     });
 });


### PR DESCRIPTION
Adding token manager address as an argument for `flowLimitExceeded` error because this information is needed in monitoring scripts. Connected to [AXE-2705](https://axelarnetwork.atlassian.net/jira/software/c/projects/AXE/boards/21?selectedIssue=AXE-2705)

[AXE-2705]: https://axelarnetwork.atlassian.net/browse/AXE-2705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ