### PR TITLE
fix: check token sender earlier

### DIFF
--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -1307,7 +1307,7 @@ describe('Interchain Token Service', () => {
             await txPaused.wait();
         });
 
-        it(`Should revert on transmit send token when not called by token manager`, async () => {
+        it(`Should revert on transmit send token when not called by interchain token`, async () => {
             const [token, , tokenId] = await deployFunctions.lockUnlock(`Test Token lockUnlock`, 'TT', 12, amount);
 
             await expectRevert(


### PR DESCRIPTION
- [x] check token is the sender before calling `takeToken` in `transmitInterchainToken`
- [x] Fix unit test. Not clear why the address derivation is different