### PR TITLE
fix: preventing original chain name & destination chain name are the same

### DIFF
--- a/contracts/InterchainTokenFactory.sol
+++ b/contracts/InterchainTokenFactory.sol
@@ -201,15 +201,8 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
         string memory destinationChain,
         uint256 gasValue
     ) external payable returns (bytes32 tokenId) {
-        bytes32 chainNameHash_;
-
-        if (bytes(originalChainName).length == 0) {
-            chainNameHash_ = chainNameHash;
-        } else {
-            revert NotSupported();
-        }
-
-        tokenId = _deployRemoteInterchainToken(chainNameHash_, salt, minter, destinationChain, gasValue);
+        if (bytes(originalChainName).length != 0) revert NotSupported();
+        tokenId = _deployRemoteInterchainToken(chainNameHash, salt, minter, destinationChain, gasValue);
     }
 
     /**
@@ -333,15 +326,8 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
         string calldata destinationChain,
         uint256 gasValue
     ) external payable returns (bytes32 tokenId) {
-        bytes32 chainNameHash_;
-
-        if (bytes(originalChain).length == 0) {
-            chainNameHash_ = chainNameHash;
-        } else {
-            revert NotSupported();
-        }
-
-        tokenId = _deployRemoteCanonicalInterchainToken(chainNameHash_, originalTokenAddress, destinationChain, gasValue);
+        if (bytes(originalChain).length != 0) revert NotSupported();
+        tokenId = _deployRemoteCanonicalInterchainToken(chainNameHash, originalTokenAddress, destinationChain, gasValue);
     }
 
     /**

--- a/contracts/InterchainTokenFactory.sol
+++ b/contracts/InterchainTokenFactory.sol
@@ -193,6 +193,7 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
             } else {
                 chainNameHash_ = keccak256(bytes(originalChainName));
             }
+            if (chainNameHash_ == keccak256(bytes(destinationChain))) revert CannotDeployRemotely(destinationChain);
 
             address sender = msg.sender;
             salt = interchainTokenSalt(chainNameHash_, sender, salt);
@@ -285,6 +286,8 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
             } else {
                 chainNameHash_ = keccak256(bytes(originalChain));
             }
+            if (chainNameHash_ == keccak256(bytes(destinationChain))) revert CannotDeployRemotely(destinationChain);
+
             // This ensures that the token manager has been deployed by this address, so it's safe to trust it.
             salt = canonicalInterchainTokenSalt(chainNameHash_, originalTokenAddress);
             tokenId = interchainTokenService.interchainTokenId(TOKEN_FACTORY_DEPLOYER, salt);

--- a/contracts/InterchainTokenFactory.sol
+++ b/contracts/InterchainTokenFactory.sol
@@ -184,23 +184,20 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
         uint8 tokenDecimals;
         bytes memory minter_ = new bytes(0);
 
-        {
-            address sender = msg.sender;
-            salt = interchainTokenSalt(chainNameHash, sender, salt);
-            tokenId = interchainTokenService.interchainTokenId(TOKEN_FACTORY_DEPLOYER, salt);
+        salt = interchainTokenSalt(chainNameHash, msg.sender, salt);
+        tokenId = interchainTokenService.interchainTokenId(TOKEN_FACTORY_DEPLOYER, salt);
 
-            IInterchainToken token = IInterchainToken(interchainTokenService.interchainTokenAddress(tokenId));
+        IInterchainToken token = IInterchainToken(interchainTokenService.interchainTokenAddress(tokenId));
 
-            tokenName = token.name();
-            tokenSymbol = token.symbol();
-            tokenDecimals = token.decimals();
+        tokenName = token.name();
+        tokenSymbol = token.symbol();
+        tokenDecimals = token.decimals();
 
-            if (minter != address(0)) {
-                if (!token.isMinter(minter)) revert NotMinter(minter);
-                if (minter == address(interchainTokenService)) revert InvalidMinter(minter);
+        if (minter != address(0)) {
+            if (!token.isMinter(minter)) revert NotMinter(minter);
+            if (minter == address(interchainTokenService)) revert InvalidMinter(minter);
 
-                minter_ = minter.toBytes();
-            }
+            minter_ = minter.toBytes();
         }
 
         tokenId = _deployInterchainToken(salt, destinationChain, tokenName, tokenSymbol, tokenDecimals, minter_, gasValue);
@@ -208,8 +205,9 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
 
     /**
      * @notice Deploys a remote interchain token on a specified destination chain.
+     * This method is deprecated and will be removed in the future. Please use the above method instead.
      * @dev originalChainName is only allowed to be '', i.e the current chain.
-     * Other source chains are not supported anymore to simplify ITS deployment behaviour.
+     * Other source chains are not supported anymore to simplify ITS token deployment behaviour.
      * @param originalChainName The name of the chain where the token originally exists.
      * @param salt The unique salt for deploying the token.
      * @param minter The address to receive the minter and operator role of the token, in addition to ITS. If the address is `address(0)`,
@@ -226,6 +224,7 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
         uint256 gasValue
     ) external payable returns (bytes32 tokenId) {
         if (bytes(originalChainName).length != 0) revert NotSupported();
+
         tokenId = deployRemoteInterchainToken(salt, minter, destinationChain, gasValue);
     }
 
@@ -290,12 +289,10 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
         bytes32 salt;
         IInterchainToken token;
 
-        {
-            // This ensures that the token manager has been deployed by this address, so it's safe to trust it.
-            salt = canonicalInterchainTokenSalt(chainNameHash, originalTokenAddress);
-            tokenId = interchainTokenService.interchainTokenId(TOKEN_FACTORY_DEPLOYER, salt);
-            token = IInterchainToken(interchainTokenService.validTokenAddress(tokenId));
-        }
+        // This ensures that the token manager has been deployed by this address, so it's safe to trust it.
+        salt = canonicalInterchainTokenSalt(chainNameHash, originalTokenAddress);
+        tokenId = interchainTokenService.interchainTokenId(TOKEN_FACTORY_DEPLOYER, salt);
+        token = IInterchainToken(interchainTokenService.validTokenAddress(tokenId));
 
         // The 3 lines below will revert if the token does not exist.
         string memory tokenName = token.name();
@@ -307,8 +304,9 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
 
     /**
      * @notice Deploys a canonical interchain token on a remote chain.
+     * This method is deprecated and will be removed in the future. Please use the above method instead.
      * @dev originalChain is only allowed to be '', i.e the current chain.
-     * Other source chains are not supported anymore to simplify ITS deployment behaviour.
+     * Other source chains are not supported anymore to simplify ITS token deployment behaviour.
      * @param originalChain The name of the chain where the token originally exists.
      * @param originalTokenAddress The address of the original token on the original chain.
      * @param destinationChain The name of the chain where the token will be deployed.
@@ -322,6 +320,7 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
         uint256 gasValue
     ) external payable returns (bytes32 tokenId) {
         if (bytes(originalChain).length != 0) revert NotSupported();
+
         tokenId = deployRemoteCanonicalInterchainToken(originalTokenAddress, destinationChain, gasValue);
     }
 

--- a/contracts/InterchainTokenFactory.sol
+++ b/contracts/InterchainTokenFactory.sol
@@ -191,9 +191,8 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
             if (bytes(originalChainName).length == 0) {
                 chainNameHash_ = chainNameHash;
             } else {
-                chainNameHash_ = keccak256(bytes(originalChainName));
+                revert NotSupported();
             }
-            if (chainNameHash_ == keccak256(bytes(destinationChain))) revert CannotDeployRemotely(destinationChain);
 
             address sender = msg.sender;
             salt = interchainTokenSalt(chainNameHash_, sender, salt);
@@ -284,9 +283,8 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
             if (bytes(originalChain).length == 0) {
                 chainNameHash_ = chainNameHash;
             } else {
-                chainNameHash_ = keccak256(bytes(originalChain));
+                revert NotSupported();
             }
-            if (chainNameHash_ == keccak256(bytes(destinationChain))) revert CannotDeployRemotely(destinationChain);
 
             // This ensures that the token manager has been deployed by this address, so it's safe to trust it.
             salt = canonicalInterchainTokenSalt(chainNameHash_, originalTokenAddress);

--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -306,7 +306,7 @@ contract InterchainTokenService is
         if (bytes(destinationChain).length == 0) {
             _deployTokenManager(tokenId, tokenManagerType, params);
         } else {
-            if (chainNameHash == keccak256(bytes(destinationChain))) revert CannotDeployRemotely(destinationChain);
+            if (chainNameHash == keccak256(bytes(destinationChain))) revert CannotDeployRemotelyToSelf();
 
             _deployRemoteTokenManager(tokenId, destinationChain, gasValue, tokenManagerType, params);
         }
@@ -348,7 +348,7 @@ contract InterchainTokenService is
 
             _deployTokenManager(tokenId, TokenManagerType.NATIVE_INTERCHAIN_TOKEN, abi.encode(minter, tokenAddress));
         } else {
-            if (chainNameHash == keccak256(bytes(destinationChain))) revert CannotDeployRemotely(destinationChain);
+            if (chainNameHash == keccak256(bytes(destinationChain))) revert CannotDeployRemotelyToSelf();
 
             _deployRemoteInterchainToken(tokenId, name, symbol, decimals, minter, destinationChain, gasValue);
         }

--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -306,6 +306,8 @@ contract InterchainTokenService is
         if (bytes(destinationChain).length == 0) {
             _deployTokenManager(tokenId, tokenManagerType, params);
         } else {
+            if (chainNameHash == keccak256(bytes(destinationChain))) revert CannotDeployRemotely(destinationChain);
+
             _deployRemoteTokenManager(tokenId, destinationChain, gasValue, tokenManagerType, params);
         }
     }
@@ -346,6 +348,8 @@ contract InterchainTokenService is
 
             _deployTokenManager(tokenId, TokenManagerType.NATIVE_INTERCHAIN_TOKEN, abi.encode(minter, tokenAddress));
         } else {
+            if (chainNameHash == keccak256(bytes(destinationChain))) revert CannotDeployRemotely(destinationChain);
+
             _deployRemoteInterchainToken(tokenId, name, symbol, decimals, minter, destinationChain, gasValue);
         }
     }

--- a/contracts/interfaces/IInterchainTokenFactory.sol
+++ b/contracts/interfaces/IInterchainTokenFactory.sol
@@ -96,7 +96,7 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
     /**
      * @notice Deploys a remote interchain token on a specified destination chain.
      * @dev originalChainName is only allowed to be '', i.e the current chain.
-     * Other source chains are not supported anymore to simplify ITS deployment behaviour.
+     * Other source chains are not supported anymore to simplify ITS token deployment behaviour.
      * @param originalChainName The name of the chain where the token originally exists.
      * @param salt The unique salt for deploying the token.
      * @param minter The address to distribute the token on the destination chain.
@@ -150,7 +150,7 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
     /**
      * @notice Deploys a canonical interchain token on a remote chain.
      * @dev originalChain is only allowed to be '', i.e the current chain.
-     * Other source chains are not supported anymore to simplify ITS deployment behaviour.
+     * Other source chains are not supported anymore to simplify ITS token deployment behaviour.
      * @param originalChain The name of the chain where the token originally exists.
      * @param originalTokenAddress The address of the original token on the original chain.
      * @param destinationChain The name of the chain where the token will be deployed.

--- a/contracts/interfaces/IInterchainTokenFactory.sol
+++ b/contracts/interfaces/IInterchainTokenFactory.sol
@@ -80,6 +80,23 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
 
     /**
      * @notice Deploys a remote interchain token on a specified destination chain.
+     * @param salt The unique salt for deploying the token.
+     * @param minter The address to distribute the token on the destination chain.
+     * @param destinationChain The name of the destination chain.
+     * @param gasValue The amount of gas to send for the deployment.
+     * @return tokenId The tokenId corresponding to the deployed InterchainToken.
+     */
+    function deployRemoteInterchainToken(
+        bytes32 salt,
+        address minter,
+        string memory destinationChain,
+        uint256 gasValue
+    ) external payable returns (bytes32 tokenId);
+
+    /**
+     * @notice Deploys a remote interchain token on a specified destination chain.
+     * @dev originalChainName is only allowed to be '', i.e the current chain.
+     * Other source chains are not supported anymore to simplify ITS deployment behaviour.
      * @param originalChainName The name of the chain where the token originally exists.
      * @param salt The unique salt for deploying the token.
      * @param minter The address to distribute the token on the destination chain.
@@ -89,22 +106,6 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
      */
     function deployRemoteInterchainToken(
         string calldata originalChainName,
-        bytes32 salt,
-        address minter,
-        string memory destinationChain,
-        uint256 gasValue
-    ) external payable returns (bytes32 tokenId);
-
-    /**
-     * @notice The deployRemoteInterchainToken with originalChainName allows deploying a remote interchain token back to the same chain, which could cause issues with ITS Hub balance tracking.
-     * To fix this, the deployRemoteInterchainToken function was overloaded to prevent self-deployemnt while still allowing self-transfers.
-     * @param salt The unique salt for deploying the token.
-     * @param minter The address to distribute the token on the destination chain.
-     * @param destinationChain The name of the destination chain.
-     * @param gasValue The amount of gas to send for the deployment.
-     * @return tokenId The tokenId corresponding to the deployed InterchainToken.
-     */
-    function deployRemoteInterchainToken(
         bytes32 salt,
         address minter,
         string memory destinationChain,
@@ -135,6 +136,21 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
 
     /**
      * @notice Deploys a canonical interchain token on a remote chain.
+     * @param originalTokenAddress The address of the original token on the original chain.
+     * @param destinationChain The name of the chain where the token will be deployed.
+     * @param gasValue The gas amount to be sent for deployment.
+     * @return tokenId The tokenId corresponding to the deployed canonical InterchainToken.
+     */
+    function deployRemoteCanonicalInterchainToken(
+        address originalTokenAddress,
+        string calldata destinationChain,
+        uint256 gasValue
+    ) external payable returns (bytes32 tokenId);
+
+    /**
+     * @notice Deploys a canonical interchain token on a remote chain.
+     * @dev originalChain is only allowed to be '', i.e the current chain.
+     * Other source chains are not supported anymore to simplify ITS deployment behaviour.
      * @param originalChain The name of the chain where the token originally exists.
      * @param originalTokenAddress The address of the original token on the original chain.
      * @param destinationChain The name of the chain where the token will be deployed.
@@ -143,20 +159,6 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
      */
     function deployRemoteCanonicalInterchainToken(
         string calldata originalChain,
-        address originalTokenAddress,
-        string calldata destinationChain,
-        uint256 gasValue
-    ) external payable returns (bytes32 tokenId);
-
-    /**
-     * @notice The deployRemoteCanonicalInterchainToken with originalChain allows deploying a canonical interchain token back to the same chain, which could cause issues with ITS Hub balance tracking.
-     * To fix this, the deployRemoteCanonicalInterchainToken function was overloaded to prevent self-deployemnt while still allowing self-transfers.
-     * @param originalTokenAddress The address of the original token on the original chain.
-     * @param destinationChain The name of the chain where the token will be deployed.
-     * @param gasValue The gas amount to be sent for deployment.
-     * @return tokenId The tokenId corresponding to the deployed canonical InterchainToken.
-     */
-    function deployRemoteCanonicalInterchainToken(
         address originalTokenAddress,
         string calldata destinationChain,
         uint256 gasValue

--- a/contracts/interfaces/IInterchainTokenFactory.sol
+++ b/contracts/interfaces/IInterchainTokenFactory.sol
@@ -20,6 +20,7 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
     error GatewayToken(address tokenAddress);
     error NotServiceOwner(address sender);
     error NotGatewayToken(string symbol);
+    error CannotDeployRemotely(string chainName);
 
     /**
      * @notice Returns the address of the interchain token service.

--- a/contracts/interfaces/IInterchainTokenFactory.sol
+++ b/contracts/interfaces/IInterchainTokenFactory.sol
@@ -20,7 +20,7 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
     error GatewayToken(address tokenAddress);
     error NotServiceOwner(address sender);
     error NotGatewayToken(string symbol);
-    error CannotDeployRemotely(string chainName);
+    error NotSupported();
 
     /**
      * @notice Returns the address of the interchain token service.

--- a/contracts/interfaces/IInterchainTokenFactory.sol
+++ b/contracts/interfaces/IInterchainTokenFactory.sol
@@ -96,6 +96,22 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
     ) external payable returns (bytes32 tokenId);
 
     /**
+     * @notice The deployRemoteInterchainToken with originalChainName allows deploying a remote interchain token back to the same chain, which could cause issues with ITS Hub balance tracking.
+     * To fix this, the deployRemoteInterchainToken function was overloaded to prevent self-deployemnt while still allowing self-transfers.
+     * @param salt The unique salt for deploying the token.
+     * @param minter The address to distribute the token on the destination chain.
+     * @param destinationChain The name of the destination chain.
+     * @param gasValue The amount of gas to send for the deployment.
+     * @return tokenId The tokenId corresponding to the deployed InterchainToken.
+     */
+    function deployRemoteInterchainToken(
+        bytes32 salt,
+        address minter,
+        string memory destinationChain,
+        uint256 gasValue
+    ) external payable returns (bytes32 tokenId);
+
+    /**
      * @notice Calculates the salt for a canonical interchain token.
      * @param chainNameHash_ The hash of the chain name.
      * @param tokenAddress The address of the token.
@@ -127,6 +143,20 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
      */
     function deployRemoteCanonicalInterchainToken(
         string calldata originalChain,
+        address originalTokenAddress,
+        string calldata destinationChain,
+        uint256 gasValue
+    ) external payable returns (bytes32 tokenId);
+
+    /**
+     * @notice The deployRemoteCanonicalInterchainToken with originalChain allows deploying a canonical interchain token back to the same chain, which could cause issues with ITS Hub balance tracking.
+     * To fix this, the deployRemoteCanonicalInterchainToken function was overloaded to prevent self-deployemnt while still allowing self-transfers.
+     * @param originalTokenAddress The address of the original token on the original chain.
+     * @param destinationChain The name of the chain where the token will be deployed.
+     * @param gasValue The gas amount to be sent for deployment.
+     * @return tokenId The tokenId corresponding to the deployed canonical InterchainToken.
+     */
+    function deployRemoteCanonicalInterchainToken(
         address originalTokenAddress,
         string calldata destinationChain,
         uint256 gasValue

--- a/contracts/interfaces/IInterchainTokenFactory.sol
+++ b/contracts/interfaces/IInterchainTokenFactory.sol
@@ -14,6 +14,7 @@ import { IInterchainTokenService } from './IInterchainTokenService.sol';
 interface IInterchainTokenFactory is IUpgradable, IMulticall {
     error ZeroAddress();
     error InvalidChainName();
+    error InvalidMinter(address minter);
     error NotMinter(address minter);
     error NotOperator(address operator);
     error GatewayToken(address tokenAddress);

--- a/contracts/interfaces/IInterchainTokenFactory.sol
+++ b/contracts/interfaces/IInterchainTokenFactory.sol
@@ -20,7 +20,6 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
     error GatewayToken(address tokenAddress);
     error NotServiceOwner(address sender);
     error NotGatewayToken(string symbol);
-    error NotSupported();
 
     /**
      * @notice Returns the address of the interchain token service.

--- a/contracts/interfaces/IInterchainTokenFactory.sol
+++ b/contracts/interfaces/IInterchainTokenFactory.sol
@@ -20,6 +20,7 @@ interface IInterchainTokenFactory is IUpgradable, IMulticall {
     error GatewayToken(address tokenAddress);
     error NotServiceOwner(address sender);
     error NotGatewayToken(string symbol);
+    error NotSupported();
 
     /**
      * @notice Returns the address of the interchain token service.

--- a/contracts/interfaces/IInterchainTokenService.sol
+++ b/contracts/interfaces/IInterchainTokenService.sol
@@ -48,7 +48,7 @@ interface IInterchainTokenService is
     error PostDeployFailed(bytes data);
     error ZeroAmount();
     error CannotDeploy(TokenManagerType);
-    error CannotDeployRemotely(string chainName);
+    error CannotDeployRemotelyToSelf();
     error InvalidGatewayTokenTransfer(bytes32 tokenId, bytes payload, string tokenSymbol, uint256 amount);
     error InvalidPayload();
     error GatewayCallFailed(bytes data);

--- a/contracts/interfaces/IInterchainTokenService.sol
+++ b/contracts/interfaces/IInterchainTokenService.sol
@@ -48,6 +48,7 @@ interface IInterchainTokenService is
     error PostDeployFailed(bytes data);
     error ZeroAmount();
     error CannotDeploy(TokenManagerType);
+    error CannotDeployRemotely(string chainName);
     error InvalidGatewayTokenTransfer(bytes32 tokenId, bytes payload, string tokenSymbol, uint256 amount);
     error InvalidPayload();
     error GatewayCallFailed(bytes data);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -40,7 +40,7 @@ const itsCompilerSettings = {
         evmVersion: process.env.EVM_VERSION || 'london',
         optimizer: {
             ...optimizerSettings,
-            runs: 150, // Reduce runs to keep bytecode size under limit
+            runs: 100, // Reduce runs to keep bytecode size under limit
         },
     },
 };

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -89,7 +89,25 @@ describe('InterchainTokenFactory', () => {
             );
 
             await expect(
-                tokenFactory.deployRemoteCanonicalInterchainToken('', token.address, destinationChain, gasValue, {
+                tokenFactory['deployRemoteCanonicalInterchainToken(string,address,string,uint256)'](
+                    '',
+                    token.address,
+                    destinationChain,
+                    gasValue,
+                    {
+                        value: gasValue,
+                    },
+                ),
+            )
+                .to.emit(service, 'InterchainTokenDeploymentStarted')
+                .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
+                .and.to.emit(gasService, 'NativeGasPaidForContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), gasValue, wallet.address)
+                .and.to.emit(gateway, 'ContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
+
+            await expect(
+                tokenFactory['deployRemoteCanonicalInterchainToken(address,string,uint256)'](token.address, destinationChain, gasValue, {
                     value: gasValue,
                 }),
             )
@@ -109,7 +127,25 @@ describe('InterchainTokenFactory', () => {
             );
 
             await expect(
-                tokenFactory.deployRemoteCanonicalInterchainToken(chainName, token.address, destinationChain, gasValue, {
+                tokenFactory['deployRemoteCanonicalInterchainToken(string,address,string,uint256)'](
+                    chainName,
+                    token.address,
+                    destinationChain,
+                    gasValue,
+                    {
+                        value: gasValue,
+                    },
+                ),
+            )
+                .to.emit(service, 'InterchainTokenDeploymentStarted')
+                .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
+                .and.to.emit(gasService, 'NativeGasPaidForContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), gasValue, wallet.address)
+                .and.to.emit(gateway, 'ContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
+
+            await expect(
+                tokenFactory['deployRemoteCanonicalInterchainToken(address,string,uint256)'](token.address, destinationChain, gasValue, {
                     value: gasValue,
                 }),
             )
@@ -401,10 +437,17 @@ describe('InterchainTokenFactory', () => {
 
             await expectRevert(
                 (gasOptions) =>
-                    tokenFactory.deployRemoteInterchainToken(chainName, salt, otherWallet.address, destinationChain, gasValue, {
-                        ...gasOptions,
-                        value: gasValue,
-                    }),
+                    tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
+                        chainName,
+                        salt,
+                        otherWallet.address,
+                        destinationChain,
+                        gasValue,
+                        {
+                            ...gasOptions,
+                            value: gasValue,
+                        },
+                    ),
                 tokenFactory,
                 'NotMinter',
                 [otherWallet.address],
@@ -412,19 +455,33 @@ describe('InterchainTokenFactory', () => {
 
             await expectRevert(
                 (gasOptions) =>
-                    tokenFactory.deployRemoteInterchainToken(chainName, salt, service.address, destinationChain, gasValue, {
-                        ...gasOptions,
-                        value: gasValue,
-                    }),
+                    tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
+                        chainName,
+                        salt,
+                        service.address,
+                        destinationChain,
+                        gasValue,
+                        {
+                            ...gasOptions,
+                            value: gasValue,
+                        },
+                    ),
                 tokenFactory,
                 'InvalidMinter',
                 [service.address],
             );
 
             await expect(
-                tokenFactory.deployRemoteInterchainToken('', salt, wallet.address, destinationChain, gasValue, {
-                    value: gasValue,
-                }),
+                tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
+                    '',
+                    salt,
+                    wallet.address,
+                    destinationChain,
+                    gasValue,
+                    {
+                        value: gasValue,
+                    },
+                ),
             )
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, wallet.address.toLowerCase(), destinationChain)
@@ -434,9 +491,86 @@ describe('InterchainTokenFactory', () => {
                 .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
 
             await expect(
-                tokenFactory.deployRemoteInterchainToken(chainName, salt, wallet.address, destinationChain, gasValue, {
-                    value: gasValue,
-                }),
+                tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
+                    chainName,
+                    salt,
+                    wallet.address,
+                    destinationChain,
+                    gasValue,
+                    {
+                        value: gasValue,
+                    },
+                ),
+            )
+                .to.emit(service, 'InterchainTokenDeploymentStarted')
+                .withArgs(tokenId, name, symbol, decimals, wallet.address.toLowerCase(), destinationChain)
+                .and.to.emit(gasService, 'NativeGasPaidForContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), gasValue, wallet.address)
+                .and.to.emit(gateway, 'ContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
+
+            await expectRevert(
+                (gasOptions) =>
+                    tokenFactory['deployRemoteInterchainToken(bytes32,address,string,uint256)'](
+                        salt,
+                        otherWallet.address,
+                        destinationChain,
+                        gasValue,
+                        {
+                            ...gasOptions,
+                            value: gasValue,
+                        },
+                    ),
+                tokenFactory,
+                'NotMinter',
+                [otherWallet.address],
+            );
+
+            await expectRevert(
+                (gasOptions) =>
+                    tokenFactory['deployRemoteInterchainToken(bytes32,address,string,uint256)'](
+                        salt,
+                        service.address,
+                        destinationChain,
+                        gasValue,
+                        {
+                            ...gasOptions,
+                            value: gasValue,
+                        },
+                    ),
+                tokenFactory,
+                'InvalidMinter',
+                [service.address],
+            );
+
+            await expect(
+                tokenFactory['deployRemoteInterchainToken(bytes32,address,string,uint256)'](
+                    salt,
+                    wallet.address,
+                    destinationChain,
+                    gasValue,
+                    {
+                        value: gasValue,
+                    },
+                ),
+            )
+                .to.emit(service, 'InterchainTokenDeploymentStarted')
+                .withArgs(tokenId, name, symbol, decimals, wallet.address.toLowerCase(), destinationChain)
+                .and.to.emit(gasService, 'NativeGasPaidForContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), gasValue, wallet.address)
+                .and.to.emit(gateway, 'ContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
+
+            await expect(
+                tokenFactory['deployRemoteInterchainToken(bytes32,address,string,uint256)'](
+                    salt,
+                    wallet.address,
+                    destinationChain,
+                    gasValue,
+                    {
+                        value: gasValue,
+                    },
+                ),
             )
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, wallet.address.toLowerCase(), destinationChain)
@@ -482,7 +616,26 @@ describe('InterchainTokenFactory', () => {
             );
 
             await expect(
-                tokenFactory.deployRemoteInterchainToken(chainName, salt, AddressZero, destinationChain, gasValue, {
+                tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
+                    chainName,
+                    salt,
+                    AddressZero,
+                    destinationChain,
+                    gasValue,
+                    {
+                        value: gasValue,
+                    },
+                ),
+            )
+                .to.emit(service, 'InterchainTokenDeploymentStarted')
+                .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
+                .and.to.emit(gasService, 'NativeGasPaidForContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), gasValue, wallet.address)
+                .and.to.emit(gateway, 'ContractCall')
+                .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
+
+            await expect(
+                tokenFactory['deployRemoteInterchainToken(bytes32,address,string,uint256)'](salt, AddressZero, destinationChain, gasValue, {
                     value: gasValue,
                 }),
             )

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -101,6 +101,20 @@ describe('InterchainTokenFactory', () => {
                 .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
         });
 
+        it('Should revert when the original chain name and the destination chain name are the same', async () => {
+            const gasValue = 1234;
+            await expectRevert(
+                (gasOptions) =>
+                    tokenFactory.deployRemoteCanonicalInterchainToken(destinationChain, token.address, destinationChain, gasValue, {
+                        ...gasOptions,
+                        value: gasValue,
+                    }),
+                tokenFactory,
+                'CannotDeployRemotely',
+                [destinationChain],
+            );
+        });
+
         it('Should initiate a remote interchain token deployment', async () => {
             const gasValue = 1234;
             const payload = defaultAbiCoder.encode(
@@ -408,6 +422,17 @@ describe('InterchainTokenFactory', () => {
                 tokenFactory,
                 'NotMinter',
                 [otherWallet.address],
+            );
+
+            await expectRevert(
+                (gasOptions) =>
+                    tokenFactory.deployRemoteInterchainToken(destinationChain, salt, otherWallet.address, destinationChain, gasValue, {
+                        ...gasOptions,
+                        value: gasValue,
+                    }),
+                tokenFactory,
+                'CannotDeployRemotely',
+                [destinationChain],
             );
 
             await expectRevert(

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -126,23 +126,20 @@ describe('InterchainTokenFactory', () => {
                 [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, name, symbol, decimals, '0x'],
             );
 
-            await expect(
-                tokenFactory['deployRemoteCanonicalInterchainToken(string,address,string,uint256)'](
-                    chainName,
-                    token.address,
-                    destinationChain,
-                    gasValue,
-                    {
-                        value: gasValue,
-                    },
-                ),
-            )
-                .to.emit(service, 'InterchainTokenDeploymentStarted')
-                .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
-                .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, destinationChain, service.address, keccak256(payload), gasValue, wallet.address)
-                .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
+            await expectRevert(
+                (gasOptions) =>
+                    tokenFactory['deployRemoteCanonicalInterchainToken(string,address,string,uint256)'](
+                        chainName,
+                        token.address,
+                        destinationChain,
+                        gasValue,
+                        {
+                            value: gasValue,
+                        },
+                    ),
+                tokenFactory,
+                'NotSupported',
+            );
 
             await expect(
                 tokenFactory['deployRemoteCanonicalInterchainToken(address,string,uint256)'](token.address, destinationChain, gasValue, {
@@ -449,6 +446,23 @@ describe('InterchainTokenFactory', () => {
                         },
                     ),
                 tokenFactory,
+                'NotSupported',
+            );
+
+            await expectRevert(
+                (gasOptions) =>
+                    tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
+                        '',
+                        salt,
+                        otherWallet.address,
+                        destinationChain,
+                        gasValue,
+                        {
+                            ...gasOptions,
+                            value: gasValue,
+                        },
+                    ),
+                tokenFactory,
                 'NotMinter',
                 [otherWallet.address],
             );
@@ -456,7 +470,7 @@ describe('InterchainTokenFactory', () => {
             await expectRevert(
                 (gasOptions) =>
                     tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
-                        chainName,
+                        '',
                         salt,
                         service.address,
                         destinationChain,
@@ -474,25 +488,6 @@ describe('InterchainTokenFactory', () => {
             await expect(
                 tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
                     '',
-                    salt,
-                    wallet.address,
-                    destinationChain,
-                    gasValue,
-                    {
-                        value: gasValue,
-                    },
-                ),
-            )
-                .to.emit(service, 'InterchainTokenDeploymentStarted')
-                .withArgs(tokenId, name, symbol, decimals, wallet.address.toLowerCase(), destinationChain)
-                .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, destinationChain, service.address, keccak256(payload), gasValue, wallet.address)
-                .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
-
-            await expect(
-                tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
-                    chainName,
                     salt,
                     wallet.address,
                     destinationChain,
@@ -560,24 +555,6 @@ describe('InterchainTokenFactory', () => {
                 .withArgs(service.address, destinationChain, service.address, keccak256(payload), gasValue, wallet.address)
                 .and.to.emit(gateway, 'ContractCall')
                 .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
-
-            await expect(
-                tokenFactory['deployRemoteInterchainToken(bytes32,address,string,uint256)'](
-                    salt,
-                    wallet.address,
-                    destinationChain,
-                    gasValue,
-                    {
-                        value: gasValue,
-                    },
-                ),
-            )
-                .to.emit(service, 'InterchainTokenDeploymentStarted')
-                .withArgs(tokenId, name, symbol, decimals, wallet.address.toLowerCase(), destinationChain)
-                .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, destinationChain, service.address, keccak256(payload), gasValue, wallet.address)
-                .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
         });
 
         it('Should initiate a remote interchain token deployment without the same minter', async () => {
@@ -617,7 +594,7 @@ describe('InterchainTokenFactory', () => {
 
             await expect(
                 tokenFactory['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
-                    chainName,
+                    '',
                     salt,
                     AddressZero,
                     destinationChain,

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -270,6 +270,16 @@ describe('InterchainTokenFactory', () => {
             expect(await tokenManager.isFlowLimiter(service.address)).to.be.true;
         };
 
+        it('Should revert an interchain token deployment with the minter as interchainTokenService', async () => {
+            const salt = keccak256('0x1245');
+            await expectRevert(
+                (gasOptions) => tokenFactory.deployInterchainToken(salt, name, symbol, decimals, 0, service.address, gasOptions),
+                tokenFactory,
+                'InvalidMinter',
+                [service.address],
+            );
+        });
+
         it('Should register a token if the mint amount is zero', async () => {
             const salt = keccak256('0x1234');
             tokenId = await tokenFactory.interchainTokenId(wallet.address, salt);
@@ -398,6 +408,17 @@ describe('InterchainTokenFactory', () => {
                 tokenFactory,
                 'NotMinter',
                 [otherWallet.address],
+            );
+
+            await expectRevert(
+                (gasOptions) =>
+                    tokenFactory.deployRemoteInterchainToken(chainName, salt, service.address, destinationChain, gasValue, {
+                        ...gasOptions,
+                        value: gasValue,
+                    }),
+                tokenFactory,
+                'InvalidMinter',
+                [service.address],
             );
 
             await expect(

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -101,20 +101,6 @@ describe('InterchainTokenFactory', () => {
                 .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
         });
 
-        it('Should revert when the original chain name and the destination chain name are the same', async () => {
-            const gasValue = 1234;
-            await expectRevert(
-                (gasOptions) =>
-                    tokenFactory.deployRemoteCanonicalInterchainToken(destinationChain, token.address, destinationChain, gasValue, {
-                        ...gasOptions,
-                        value: gasValue,
-                    }),
-                tokenFactory,
-                'CannotDeployRemotely',
-                [destinationChain],
-            );
-        });
-
         it('Should initiate a remote interchain token deployment', async () => {
             const gasValue = 1234;
             const payload = defaultAbiCoder.encode(
@@ -422,17 +408,6 @@ describe('InterchainTokenFactory', () => {
                 tokenFactory,
                 'NotMinter',
                 [otherWallet.address],
-            );
-
-            await expectRevert(
-                (gasOptions) =>
-                    tokenFactory.deployRemoteInterchainToken(destinationChain, salt, otherWallet.address, destinationChain, gasValue, {
-                        ...gasOptions,
-                        value: gasValue,
-                    }),
-                tokenFactory,
-                'CannotDeployRemotely',
-                [destinationChain],
             );
 
             await expectRevert(

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -548,6 +548,47 @@ describe('Interchain Token Service', () => {
 
             await deployContract(wallet, 'TokenManagerProxy', [service.address, LOCK_UNLOCK, tokenId, validParams]);
         });
+
+        it('Should revert when deploying a remote interchain token to self', async () => {
+            const tokenName = 'Token Name';
+            const tokenSymbol = 'TN';
+            const tokenDecimals = 13;
+            const salt = getRandomBytes32();
+
+            await expectRevert(
+                (gasOptions) =>
+                    serviceTest.deployInterchainToken(
+                        salt,
+                        chainName,
+                        tokenName,
+                        tokenSymbol,
+                        tokenDecimals,
+                        wallet.address,
+                        0,
+                        gasOptions,
+                    ),
+                serviceTest,
+                'CannotDeployRemotelyToSelf',
+            );
+        });
+
+        it('Should revert when deploying a remote token manager to self', async () => {
+            const salt = getRandomBytes32();
+
+            await expectRevert(
+                (gasOptions) =>
+                    serviceTest.deployTokenManager(
+                        salt,
+                        chainName,
+                        LOCK_UNLOCK,
+                        defaultAbiCoder.encode(['bytes', 'address'], ['0x', testToken.address]),
+                        0,
+                        gasOptions,
+                    ),
+                serviceTest,
+                'CannotDeployRemotelyToSelf',
+            );
+        });
     });
 
     describe('Owner functions', () => {

--- a/test/InterchainTokenServiceFullFlow.js
+++ b/test/InterchainTokenServiceFullFlow.js
@@ -73,8 +73,7 @@ describe('Interchain Token Service Full Flow', () => {
             let value = 0;
 
             for (const i in otherChains) {
-                tx = await tokenFactory.populateTransaction['deployRemoteCanonicalInterchainToken(string,address,string,uint256)'](
-                    chainName,
+                tx = await tokenFactory.populateTransaction['deployRemoteCanonicalInterchainToken(address,string,uint256)'](
                     token.address,
                     otherChains[i],
                     gasValues[i],
@@ -177,8 +176,7 @@ describe('Interchain Token Service Full Flow', () => {
 
             // Deploy a linked Interchain token to remote chains.
             for (const i in otherChains) {
-                tx = await tokenFactory.populateTransaction['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
-                    chainName,
+                tx = await tokenFactory.populateTransaction['deployRemoteInterchainToken(bytes32,address,string,uint256)'](
                     salt,
                     wallet.address,
                     otherChains[i],
@@ -485,8 +483,7 @@ describe('Interchain Token Service Full Flow', () => {
 
             // Deploy a linked Interchain token to remote chains.
             for (const i in otherChains) {
-                tx = await tokenFactory.populateTransaction['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
-                    chainName,
+                tx = await tokenFactory.populateTransaction['deployRemoteInterchainToken(bytes32,address,string,uint256)'](
                     salt,
                     AddressZero,
                     otherChains[i],
@@ -703,8 +700,7 @@ describe('Interchain Token Service Full Flow', () => {
 
             // Deploy a linked Interchain token to remote chains.
             for (const i in otherChains) {
-                tx = await tokenFactory.populateTransaction['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
-                    chainName,
+                tx = await tokenFactory.populateTransaction['deployRemoteInterchainToken(bytes32,address,string,uint256)'](
                     salt,
                     wallet.address,
                     otherChains[i],

--- a/test/InterchainTokenServiceFullFlow.js
+++ b/test/InterchainTokenServiceFullFlow.js
@@ -73,7 +73,7 @@ describe('Interchain Token Service Full Flow', () => {
             let value = 0;
 
             for (const i in otherChains) {
-                tx = await tokenFactory.populateTransaction.deployRemoteCanonicalInterchainToken(
+                tx = await tokenFactory.populateTransaction['deployRemoteCanonicalInterchainToken(string,address,string,uint256)'](
                     chainName,
                     token.address,
                     otherChains[i],
@@ -177,7 +177,7 @@ describe('Interchain Token Service Full Flow', () => {
 
             // Deploy a linked Interchain token to remote chains.
             for (const i in otherChains) {
-                tx = await tokenFactory.populateTransaction.deployRemoteInterchainToken(
+                tx = await tokenFactory.populateTransaction['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
                     chainName,
                     salt,
                     wallet.address,
@@ -485,7 +485,7 @@ describe('Interchain Token Service Full Flow', () => {
 
             // Deploy a linked Interchain token to remote chains.
             for (const i in otherChains) {
-                tx = await tokenFactory.populateTransaction.deployRemoteInterchainToken(
+                tx = await tokenFactory.populateTransaction['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
                     chainName,
                     salt,
                     AddressZero,
@@ -703,7 +703,7 @@ describe('Interchain Token Service Full Flow', () => {
 
             // Deploy a linked Interchain token to remote chains.
             for (const i in otherChains) {
-                tx = await tokenFactory.populateTransaction.deployRemoteInterchainToken(
+                tx = await tokenFactory.populateTransaction['deployRemoteInterchainToken(string,bytes32,address,string,uint256)'](
                     chainName,
                     salt,
                     wallet.address,


### PR DESCRIPTION
[AXE-4776](https://axelarnetwork.atlassian.net/browse/AXE-4776)

- In `InterchainTokenFactory.deployRemoteInterchainToken`, check if `destinationChain` is the same as `originalChainName` to prevent remote deployment requests to the original chain.
- Check originalChainName and destinationChain in `InterchainTokenFactory.deployRemoteCanonicalInterchainToken` to ensure that a remote deploy cannot be requested to the original chain.
- Unit test coverage is 100% for `InterchainTokenFactory.sol` and `InterchainTokenService.sol`
```
----------------------------------------|----------|----------|----------|----------|----------------|
File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------------------------|----------|----------|----------|----------|----------------|
  InterchainTokenFactory.sol            |      100 |      100 |      100 |      100 |                |
  InterchainTokenService.sol            |      100 |      100 |      100 |      100 |                |

```

[AXE-4776]: https://axelarnetwork.atlassian.net/browse/AXE-4776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ