### PR TITLE
fix: modified wrong data decoding in _checkPayloadAgainstGatewayData

### DIFF
--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -707,7 +707,7 @@ contract InterchainTokenService is
      * @param amount The amount for the call contract with token.
      */
     function _checkPayloadAgainstGatewayData(bytes memory payload, string calldata tokenSymbol, uint256 amount) internal view {
-        (, bytes32 tokenId, , , uint256 amountInPayload) = abi.decode(payload, (uint256, bytes32, uint256, uint256, uint256));
+        (, bytes32 tokenId, , , uint256 amountInPayload) = abi.decode(payload, (uint256, bytes32, bytes, bytes, uint256));
 
         if (validTokenAddress(tokenId) != gateway.tokenAddresses(tokenSymbol) || amount != amountInPayload)
             revert InvalidGatewayTokenTransfer(tokenId, payload, tokenSymbol, amount);

--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -707,7 +707,8 @@ contract InterchainTokenService is
      * @param amount The amount for the call contract with token.
      */
     function _checkPayloadAgainstGatewayData(bytes memory payload, string calldata tokenSymbol, uint256 amount) internal view {
-        // Using `uint256` instead of `bytes` for unnecessary values improves gas efficiency without affecting functionality.
+        // The same payload is decoded in both _checkPayloadAgainstGatewayData and _contractCallValue using different parameters.
+        // This is intentional, as using `uint256` instead of `bytes` improves gas efficiency without any functional difference.
         (, bytes32 tokenId, , , uint256 amountInPayload) = abi.decode(payload, (uint256, bytes32, uint256, uint256, uint256));
 
         if (validTokenAddress(tokenId) != gateway.tokenAddresses(tokenSymbol) || amount != amountInPayload)
@@ -1220,8 +1221,7 @@ contract InterchainTokenService is
      * @return uint256 The value the call is worth.
      */
     function _contractCallValue(bytes calldata payload) internal view returns (address, uint256) {
-        // Using `uint256` instead of `bytes` for unnecessary values improves gas efficiency without affecting functionality.
-        (uint256 messageType, bytes32 tokenId, , , uint256 amount) = abi.decode(payload, (uint256, bytes32, uint256, uint256, uint256));
+        (uint256 messageType, bytes32 tokenId, , , uint256 amount) = abi.decode(payload, (uint256, bytes32, bytes, bytes, uint256));
         if (messageType != MESSAGE_TYPE_INTERCHAIN_TRANSFER) {
             revert InvalidExpressMessageType(messageType);
         }

--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -707,7 +707,9 @@ contract InterchainTokenService is
      * @param amount The amount for the call contract with token.
      */
     function _checkPayloadAgainstGatewayData(bytes memory payload, string calldata tokenSymbol, uint256 amount) internal view {
-        (, bytes32 tokenId, , , uint256 amountInPayload) = abi.decode(payload, (uint256, bytes32, bytes, bytes, uint256));
+        // The same payload is decoded in both _checkPayloadAgainstGatewayData and _contractCallValue using different parameters.
+        // This is intentional, as using `uint256` instead of `bytes` improves gas efficiency without any functional difference.
+        (, bytes32 tokenId, , , uint256 amountInPayload) = abi.decode(payload, (uint256, bytes32, uint256, uint256, uint256));
 
         if (validTokenAddress(tokenId) != gateway.tokenAddresses(tokenSymbol) || amount != amountInPayload)
             revert InvalidGatewayTokenTransfer(tokenId, payload, tokenSymbol, amount);

--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -707,8 +707,7 @@ contract InterchainTokenService is
      * @param amount The amount for the call contract with token.
      */
     function _checkPayloadAgainstGatewayData(bytes memory payload, string calldata tokenSymbol, uint256 amount) internal view {
-        // The same payload is decoded in both _checkPayloadAgainstGatewayData and _contractCallValue using different parameters.
-        // This is intentional, as using `uint256` instead of `bytes` improves gas efficiency without any functional difference.
+        // Using `uint256` instead of `bytes` for unnecessary values improves gas efficiency without affecting functionality.
         (, bytes32 tokenId, , , uint256 amountInPayload) = abi.decode(payload, (uint256, bytes32, uint256, uint256, uint256));
 
         if (validTokenAddress(tokenId) != gateway.tokenAddresses(tokenSymbol) || amount != amountInPayload)
@@ -1221,7 +1220,8 @@ contract InterchainTokenService is
      * @return uint256 The value the call is worth.
      */
     function _contractCallValue(bytes calldata payload) internal view returns (address, uint256) {
-        (uint256 messageType, bytes32 tokenId, , , uint256 amount) = abi.decode(payload, (uint256, bytes32, bytes, bytes, uint256));
+        // Using `uint256` instead of `bytes` for unnecessary values improves gas efficiency without affecting functionality.
+        (uint256 messageType, bytes32 tokenId, , , uint256 amount) = abi.decode(payload, (uint256, bytes32, uint256, uint256, uint256));
         if (messageType != MESSAGE_TYPE_INTERCHAIN_TRANSFER) {
             revert InvalidExpressMessageType(messageType);
         }


### PR DESCRIPTION
[AXE-4792](https://axelarnetwork.atlassian.net/browse/AXE-4792)
- Modified [L-01] Wrong data decoding in _checkPayloadAgainstGatewayData
- Unit test coverage remains the same

[AXE-4792]: https://axelarnetwork.atlassian.net/browse/AXE-4792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ