### PR TITLE
fix: remove redundant check on the v value

### DIFF
--- a/contracts/interchain-token/ERC20Permit.sol
+++ b/contracts/interchain-token/ERC20Permit.sol
@@ -15,7 +15,6 @@ import { ERC20 } from './ERC20.sol';
 abstract contract ERC20Permit is IERC20, IERC20Permit, ERC20 {
     error PermitExpired();
     error InvalidS();
-    error InvalidV();
     error InvalidSignature();
 
     /**
@@ -72,8 +71,6 @@ abstract contract ERC20Permit is IERC20, IERC20Permit, ERC20 {
         if (block.timestamp > deadline) revert PermitExpired();
 
         if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) revert InvalidS();
-
-        if (v != 27 && v != 28) revert InvalidV();
 
         bytes32 digest = keccak256(
             abi.encodePacked(

--- a/test/ERC20Permit.js
+++ b/test/ERC20Permit.js
@@ -172,13 +172,6 @@ describe('ERC20 Permit', () => {
 
         await expectRevert(
             (gasOptions) =>
-                token.connect(owner).permit(user.address, owner.address, allowance, deadline, 0, signature.r, signature.s, gasOptions),
-            token,
-            'InvalidV',
-        );
-
-        await expectRevert(
-            (gasOptions) =>
                 token
                     .connect(owner)
                     .permit(owner.address, owner.address, allowance, deadline, signature.v, signature.r, signature.s, gasOptions),

--- a/test/InterchainToken.js
+++ b/test/InterchainToken.js
@@ -147,7 +147,7 @@ describe('InterchainToken', () => {
             const contractBytecodeHash = keccak256(contractBytecode);
 
             const expected = {
-                london: '0xa01cf28b0b6ce6dc3b466e995585d69486400d671fce0ea8d06beba583e6f3bb',
+                london: '0xb13b7218e227186d16ed3cac7cdcbd379dc9afd2061435f1b3f78a2c851a86a2',
             }[getEVMVersion()];
 
             expect(contractBytecodeHash).to.be.equal(expected);


### PR DESCRIPTION
[AXE-4803](https://axelarnetwork.atlassian.net/browse/AXE-4803)
- Remove Unnecessary v value check in ERC20Permit#permit()
- The ERC20Permit contract implements an unnecessary check for the signature recovery ID (v) before calling the ecrecover function. This check is redundant as ecrecover inherently validates these values.
- The ecrecover function and the subsequent check for a valid recovered address are sufficient to ensure the signature's validity.
- Addressing it will optimize gas usage and simplify the contract code. This change aligns with best practices in Ethereum smart contract development, emphasizing efficiency and clarity in code implementation.

References:
- https://twitter.com/alexberegszaszi/status/1534461421454606336?s=20&t=H0Dv3ZT2bicx00hLWJk7Fg
- The latest [Openzeppelin's ECDSA](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/530179a71f435e85ae9df9b9f12b5637cf229e5c/contracts/utils/cryptography/ECDSA.sol#L136) has removed the v check. by [PR#3591](https://github.com/OpenZeppelin/openzeppelin-contracts/commit/324eda228c07468a0744fc52677e6cebea5dc5c5#diff-ff09871806bcccfd38e43de481f3e7e2fb92134c58e1a1f97b054e2d0d727458) 



[AXE-4803]: https://axelarnetwork.atlassian.net/browse/AXE-4803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ