### PR TITLE
fix!: use lower case ITS hub chain name

### DIFF
--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -91,7 +91,7 @@ contract InterchainTokenService is
      * @dev Chain name where ITS Hub exists. This is used for routing ITS calls via ITS hub.
      * This is set as a constant, since the ITS Hub will exist on Axelar.
      */
-    string internal constant ITS_HUB_CHAIN_NAME = 'Axelarnet';
+    string internal constant ITS_HUB_CHAIN_NAME = 'axelarnet';
     bytes32 internal constant ITS_HUB_CHAIN_NAME_HASH = keccak256(abi.encodePacked(ITS_HUB_CHAIN_NAME));
 
     /**

--- a/test/constants.js
+++ b/test/constants.js
@@ -19,7 +19,7 @@ const OPERATOR_ROLE = 1;
 const FLOW_LIMITER_ROLE = 2;
 
 // Chain name for ITS Hub chain
-const ITS_HUB_CHAIN_NAME = 'Axelarnet';
+const ITS_HUB_CHAIN_NAME = 'axelarnet';
 const ITS_HUB_ROUTING_IDENTIFIER = 'hub';
 const ITS_HUB_ADDRESS = 'axelar1xyz';
 


### PR DESCRIPTION
Devnet amplifier ITS hub instance uses `axelarnet` as the chain name (via the axelarnet-gateway)

[AXE-5292]

[AXE-5292]: https://axelarnetwork.atlassian.net/browse/AXE-5292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ