### PR TITLE
chore: added InterchainTokenIdClaimed event

### DIFF
--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -341,6 +341,8 @@ contract InterchainTokenService is
 
         tokenId = interchainTokenId(deployer, salt);
 
+        emit InterchainTokenIdClaimed(tokenId, deployer, salt);
+
         if (bytes(destinationChain).length == 0) {
             address tokenAddress = _deployInterchainToken(tokenId, minter, name, symbol, decimals);
 

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -699,6 +699,8 @@ describe('Interchain Token Service', () => {
                     'Send deployInterchainToken to remote chain',
                 ),
             )
+                .to.emit(service, 'InterchainTokenIdClaimed')
+                .withArgs(tokenId, wallet.address, salt)
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, tokenName, tokenSymbol, tokenDecimals, minter, destinationChain)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')
@@ -1089,6 +1091,8 @@ describe('Interchain Token Service', () => {
                     'Send deployTokenManager to remote chain',
                 ),
             )
+                .to.emit(service, 'InterchainTokenIdClaimed')
+                .withArgs(tokenId, wallet.address, salt)
                 .to.emit(service, 'TokenManagerDeploymentStarted')
                 .withArgs(tokenId, destinationChain, type, params)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -621,6 +621,8 @@ describe('Interchain Token Service', () => {
                     'Call deployInterchainToken on source chain',
                 ),
             )
+                .to.emit(service, 'InterchainTokenIdClaimed')
+                .withArgs(tokenId, wallet.address, salt)
                 .to.emit(service, 'InterchainTokenDeployed')
                 .withArgs(tokenId, tokenAddress, wallet.address, tokenName, tokenSymbol, tokenDecimals)
                 .to.emit(service, 'TokenManagerDeployed')
@@ -846,6 +848,8 @@ describe('Interchain Token Service', () => {
             const params = defaultAbiCoder.encode(['bytes', 'address'], [wallet.address, token.address]);
 
             await expect(reportGas(service.deployTokenManager(salt, '', LOCK_UNLOCK, params, 0), 'Call deployTokenManager on source chain'))
+                .to.emit(service, 'InterchainTokenIdClaimed')
+                .withArgs(tokenId, wallet.address, salt)
                 .to.emit(service, 'TokenManagerDeployed')
                 .withArgs(tokenId, tokenManagerAddress, LOCK_UNLOCK, params);
 


### PR DESCRIPTION
[AXE-5210](https://axelarnetwork.atlassian.net/browse/AXE-5210)
- added `InterchainTokenIdClaimed` event
- `coverage` remains the same. 

[AXE-5210]: https://axelarnetwork.atlassian.net/browse/AXE-5210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ