### PR TITLE
fix(its): validate token manager address from token id

### DIFF
--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -413,9 +413,6 @@ contract InterchainTokenService is
 
         IERC20 token;
         {
-            // slither-disable-next-line unused-return
-            validTokenManagerAddress(tokenId);
-
             (bool success, bytes memory returnData) = tokenHandler.delegatecall(
                 abi.encodeWithSelector(ITokenHandler.transferTokenFrom.selector, tokenId, msg.sender, destinationAddress, amount)
             );
@@ -1196,9 +1193,6 @@ contract InterchainTokenService is
      * @dev Takes token from a sender via the token service. `tokenOnly` indicates if the caller should be restricted to the token only.
      */
     function _takeToken(bytes32 tokenId, address from, uint256 amount, bool tokenOnly) internal returns (uint256, string memory symbol) {
-        // slither-disable-next-line unused-return
-        validTokenManagerAddress(tokenId);
-
         (bool success, bytes memory data) = tokenHandler.delegatecall(
             abi.encodeWithSelector(ITokenHandler.takeToken.selector, tokenId, tokenOnly, from, amount)
         );
@@ -1212,9 +1206,6 @@ contract InterchainTokenService is
      * @dev Gives token to recipient via the token service.
      */
     function _giveToken(bytes32 tokenId, address to, uint256 amount) internal returns (uint256, address tokenAddress) {
-        // slither-disable-next-line unused-return
-        validTokenManagerAddress(tokenId);
-
         (bool success, bytes memory data) = tokenHandler.delegatecall(
             abi.encodeWithSelector(ITokenHandler.giveToken.selector, tokenId, to, amount)
         );

--- a/contracts/InterchainTokenService.sol
+++ b/contracts/InterchainTokenService.sol
@@ -413,6 +413,9 @@ contract InterchainTokenService is
 
         IERC20 token;
         {
+            // slither-disable-next-line unused-return
+            validTokenManagerAddress(tokenId);
+
             (bool success, bytes memory returnData) = tokenHandler.delegatecall(
                 abi.encodeWithSelector(ITokenHandler.transferTokenFrom.selector, tokenId, msg.sender, destinationAddress, amount)
             );
@@ -1193,6 +1196,9 @@ contract InterchainTokenService is
      * @dev Takes token from a sender via the token service. `tokenOnly` indicates if the caller should be restricted to the token only.
      */
     function _takeToken(bytes32 tokenId, address from, uint256 amount, bool tokenOnly) internal returns (uint256, string memory symbol) {
+        // slither-disable-next-line unused-return
+        validTokenManagerAddress(tokenId);
+
         (bool success, bytes memory data) = tokenHandler.delegatecall(
             abi.encodeWithSelector(ITokenHandler.takeToken.selector, tokenId, tokenOnly, from, amount)
         );
@@ -1206,6 +1212,9 @@ contract InterchainTokenService is
      * @dev Gives token to recipient via the token service.
      */
     function _giveToken(bytes32 tokenId, address to, uint256 amount) internal returns (uint256, address tokenAddress) {
+        // slither-disable-next-line unused-return
+        validTokenManagerAddress(tokenId);
+
         (bool success, bytes memory data) = tokenHandler.delegatecall(
             abi.encodeWithSelector(ITokenHandler.giveToken.selector, tokenId, to, amount)
         );

--- a/contracts/interfaces/ITokenHandler.sol
+++ b/contracts/interfaces/ITokenHandler.sol
@@ -10,6 +10,7 @@ interface ITokenHandler {
     error UnsupportedTokenManagerType(uint256 tokenManagerType);
     error AddressZero();
     error NotToken(address caller, address token);
+    error TokenManagerDoesNotExist(bytes32 tokenId);
 
     /**
      * @notice Returns the address of the axelar gateway on this chain.

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -1300,8 +1300,7 @@ describe('Interchain Token Service', () => {
                         value: gasValue,
                     }),
                 service,
-                'TokenManagerDoesNotExist',
-                [invalidTokenId],
+                'TakeTokenFailed',
             );
         });
 
@@ -2616,8 +2615,7 @@ describe('Interchain Token Service', () => {
             await expectRevert(
                 (gasOptions) => service.expressExecute(commandId, sourceChain, sourceAddress, payload, gasOptions),
                 service,
-                'TokenManagerDoesNotExist',
-                [invalidTokenId],
+                'TokenHandlerFailed',
             );
         });
 


### PR DESCRIPTION
[AXE-4705](https://axelarnetwork.atlassian.net/browse/AXE-4705)
- validate token manager address from token id
- coverage remains the same
```
----------------------------------------|----------|----------|----------|----------|----------------|
File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------------------------|----------|----------|----------|----------|----------------|
  InterchainTokenFactory.sol            |      100 |      100 |      100 |      100 |                |
  InterchainTokenService.sol            |      100 |      100 |      100 |      100 |                |
```

[AXE-4705]: https://axelarnetwork.atlassian.net/browse/AXE-4705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ