### PR TITLE
feat(its): remove gateway token check for registerCanonicalInterchainToken

### DIFF
--- a/contracts/InterchainTokenFactory.sol
+++ b/contracts/InterchainTokenFactory.sol
@@ -267,10 +267,8 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
      */
     function registerCanonicalInterchainToken(address tokenAddress) external payable returns (bytes32 tokenId) {
         bytes memory params = abi.encode('', tokenAddress);
-
-        if (_isGatewayToken(tokenAddress)) revert GatewayToken(tokenAddress);
-
         bytes32 salt = canonicalInterchainTokenSalt(chainNameHash, tokenAddress);
+
         tokenId = interchainTokenService.deployTokenManager(salt, '', TokenManagerType.LOCK_UNLOCK, params, 0);
     }
 
@@ -337,15 +335,5 @@ contract InterchainTokenFactory is IInterchainTokenFactory, ITokenManagerType, M
         bytes32 salt = gatewayTokenSalt(tokenIdentifier);
 
         tokenId = interchainTokenService.deployTokenManager(salt, '', TokenManagerType.GATEWAY, params, 0);
-    }
-
-    /**
-     * @notice Checks if a given token is a gateway token.
-     * @param token The address of the token to check.
-     * @return bool True if the token is a gateway token, false otherwise.
-     */
-    function _isGatewayToken(address token) internal view returns (bool) {
-        string memory symbol = IInterchainToken(token).symbol();
-        return token == gateway.tokenAddresses(symbol);
     }
 }

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -153,46 +153,6 @@ describe('InterchainTokenFactory', () => {
                 .and.to.emit(gateway, 'ContractCall')
                 .withArgs(service.address, destinationChain, service.address, keccak256(payload), payload);
         });
-
-        it('Should revert when trying to register a canonical lock/unlock gateway token', async () => {
-            const tokenCap = 0;
-            const mintLimit = 0;
-            const tokenAddress = token.address;
-
-            const params = defaultAbiCoder.encode(
-                ['string', 'string', 'uint8', 'uint256', 'address', 'uint256'],
-                [name, symbol, decimals, tokenCap, tokenAddress, mintLimit],
-            );
-            await gateway.deployToken(params, getRandomBytes32()).then((tx) => tx.wait);
-
-            await expectRevert(
-                (gasOptions) => tokenFactory.registerCanonicalInterchainToken(tokenAddress, gasOptions),
-                tokenFactory,
-                'GatewayToken',
-                [tokenAddress],
-            );
-        });
-
-        it('Should revert when trying to register a canonical mint/burn gateway token', async () => {
-            const tokenCap = 0;
-            let tokenAddress = AddressZero;
-            const mintLimit = 0;
-            const newSymbol = 'NewSymbol';
-            const params = defaultAbiCoder.encode(
-                ['string', 'string', 'uint8', 'uint256', 'address', 'uint256'],
-                [name, newSymbol, decimals, tokenCap, tokenAddress, mintLimit],
-            );
-            await gateway.deployToken(params, getRandomBytes32()).then((tx) => tx.wait);
-
-            tokenAddress = await gateway.tokenAddresses(newSymbol);
-
-            await expectRevert(
-                (gasOptions) => tokenFactory.registerCanonicalInterchainToken(tokenAddress, gasOptions),
-                tokenFactory,
-                'GatewayToken',
-                [tokenAddress],
-            );
-        });
     });
 
     describe('Gateway Interchain Token Factory', async () => {


### PR DESCRIPTION
[AXE-5581](https://axelarnetwork.atlassian.net/browse/AXE-5581)
- Remove gateway token check for registerCanonicalInterchainToken in Interchain Token Factory
- Coverage remains 100%:
```
----------------------------------------|----------|----------|----------|----------|----------------|
File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------------------------|----------|----------|----------|----------|----------------|
  InterchainTokenFactory.sol            |      100 |      100 |      100 |      100 |                |
```

[AXE-5581]: https://axelarnetwork.atlassian.net/browse/AXE-5581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ