### PR TITLE
ci: set package publish visibility to public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "engines": {
     "node": ">=18"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@axelar-network/axelar-cgp-solidity": "6.4.0",
     "@axelar-network/axelar-gmp-sdk-solidity": "6.0.3"


### PR DESCRIPTION
# What:

- Set the package's publish visibility to `public`.