### PR TITLE
refactor: use its message encoding for tests

### DIFF
--- a/test/AddressDerivation.js
+++ b/test/AddressDerivation.js
@@ -9,16 +9,10 @@ const {
 } = ethers;
 const { deployAll } = require('../scripts/deploy');
 const { approveContractCall } = require('../scripts/utils');
-const { getRandomBytes32, getSaltFromKey, isHardhat, getContractJSON, encodeITSPayload } = require('./utils');
+const { getRandomBytes32, getSaltFromKey, isHardhat, getContractJSON, encodeDeployInterchainToken } = require('./utils');
 const { create3DeployContract } = require('@axelar-network/axelar-gmp-sdk-solidity');
 const Token = getContractJSON('TestInterchainTokenStandard');
-const {
-    NATIVE_INTERCHAIN_TOKEN,
-    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
-    MESSAGE_TYPE_RECEIVE_FROM_HUB,
-    ITS_HUB_ADDRESS,
-    ITS_HUB_CHAIN,
-} = require('./constants');
+const { NATIVE_INTERCHAIN_TOKEN, MESSAGE_TYPE_RECEIVE_FROM_HUB, ITS_HUB_ADDRESS, ITS_HUB_CHAIN } = require('./constants');
 
 if (isHardhat) {
     describe('Token Address Derivation [ @skip-on-coverage ]', () => {
@@ -63,14 +57,15 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x3B058fE7Ed045f56F0152AED1e8c5fbaE7e23C70';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
-                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                const { payload } = encodeDeployInterchainToken(
+                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
+                    sourceChain,
                     tokenId,
                     tokenName,
                     tokenSymbol,
                     tokenDecimals,
                     minter,
-                ]);
+                );
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -90,14 +85,15 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x89AF99D9373722De5F29ABbF706efeD020ae3E1F';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
-                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                const { payload } = encodeDeployInterchainToken(
+                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
+                    sourceChain,
                     tokenId,
                     tokenName,
                     tokenSymbol,
                     tokenDecimals,
                     minter,
-                ]);
+                );
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -137,14 +133,15 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x1695DD538BeDd759BE212Ed24f809eA51dbc08D0';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
-                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                const { payload } = encodeDeployInterchainToken(
+                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
+                    sourceChain,
                     tokenId,
                     tokenName,
                     tokenSymbol,
                     tokenDecimals,
                     minter,
-                ]);
+                );
 
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
@@ -165,14 +162,15 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x123908f4742664f68db857c6a10c846fb557AF08';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
-                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                const { payload } = encodeDeployInterchainToken(
+                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
+                    sourceChain,
                     tokenId,
                     tokenName,
                     tokenSymbol,
                     tokenDecimals,
                     '0x',
-                ]);
+                );
 
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
@@ -192,14 +190,15 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x43eb02B89a4478128Df888260254efFd75b6D2eA';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
-                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                const { payload } = encodeDeployInterchainToken(
+                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
+                    sourceChain,
                     tokenId,
                     tokenName,
                     tokenSymbol,
                     tokenDecimals,
                     minter,
-                ]);
+                );
 
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 

--- a/test/AddressDerivation.js
+++ b/test/AddressDerivation.js
@@ -15,11 +15,11 @@ const {
     isHardhat,
     getContractJSON,
     encodeDeployInterchainTokenMessage,
-    encodeHubMessage,
+    encodeReceiveHubMessage,
 } = require('./utils');
 const { create3DeployContract } = require('@axelar-network/axelar-gmp-sdk-solidity');
 const Token = getContractJSON('TestInterchainTokenStandard');
-const { NATIVE_INTERCHAIN_TOKEN, MESSAGE_TYPE_RECEIVE_FROM_HUB, ITS_HUB_ADDRESS, ITS_HUB_CHAIN } = require('./constants');
+const { NATIVE_INTERCHAIN_TOKEN, ITS_HUB_ADDRESS, ITS_HUB_CHAIN } = require('./constants');
 
 if (isHardhat) {
     describe('Token Address Derivation [ @skip-on-coverage ]', () => {
@@ -64,8 +64,10 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x3B058fE7Ed045f56F0152AED1e8c5fbaE7e23C70';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
-                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+                const { payload } = encodeReceiveHubMessage(
+                    sourceChain,
+                    encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter),
+                );
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -85,8 +87,10 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x89AF99D9373722De5F29ABbF706efeD020ae3E1F';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
-                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+                const { payload } = encodeReceiveHubMessage(
+                    sourceChain,
+                    encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter),
+                );
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -126,8 +130,10 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x1695DD538BeDd759BE212Ed24f809eA51dbc08D0';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
-                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+                const { payload } = encodeReceiveHubMessage(
+                    sourceChain,
+                    encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter),
+                );
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -147,8 +153,10 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x123908f4742664f68db857c6a10c846fb557AF08';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, '0x');
-                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+                const { payload } = encodeReceiveHubMessage(
+                    sourceChain,
+                    encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, '0x'),
+                );
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -167,8 +175,10 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x43eb02B89a4478128Df888260254efFd75b6D2eA';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
-                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+                const { payload } = encodeReceiveHubMessage(
+                    sourceChain,
+                    encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter),
+                );
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))

--- a/test/AddressDerivation.js
+++ b/test/AddressDerivation.js
@@ -9,7 +9,7 @@ const {
 } = ethers;
 const { deployAll } = require('../scripts/deploy');
 const { approveContractCall } = require('../scripts/utils');
-const { getRandomBytes32, getSaltFromKey, isHardhat, getContractJSON } = require('./utils');
+const { getRandomBytes32, getSaltFromKey, isHardhat, getContractJSON, encodeITSPayload } = require('./utils');
 const { create3DeployContract } = require('@axelar-network/axelar-gmp-sdk-solidity');
 const Token = getContractJSON('TestInterchainTokenStandard');
 const {
@@ -63,17 +63,17 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x3B058fE7Ed045f56F0152AED1e8c5fbaE7e23C70';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const payload = defaultAbiCoder.encode(
-                    ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
-                    [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, tokenName, tokenSymbol, tokenDecimals, minter],
-                );
-                const wrappedPayload = defaultAbiCoder.encode(
-                    ['uint256', 'string', 'bytes'],
-                    [MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload],
-                );
-                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload);
+                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
+                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                    tokenId,
+                    tokenName,
+                    tokenSymbol,
+                    tokenDecimals,
+                    minter,
+                ]);
+                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
-                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload))
+                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
                     .to.emit(service, 'InterchainTokenDeployed')
                     .withArgs(tokenId, expectedTokenAddress, minter, tokenName, tokenSymbol, tokenDecimals)
                     .and.to.emit(service, 'TokenManagerDeployed')
@@ -90,17 +90,17 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x89AF99D9373722De5F29ABbF706efeD020ae3E1F';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const payload = defaultAbiCoder.encode(
-                    ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
-                    [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, tokenName, tokenSymbol, tokenDecimals, minter],
-                );
-                const wrappedPayload = defaultAbiCoder.encode(
-                    ['uint256', 'string', 'bytes'],
-                    [MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload],
-                );
-                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload);
+                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
+                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                    tokenId,
+                    tokenName,
+                    tokenSymbol,
+                    tokenDecimals,
+                    minter,
+                ]);
+                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
-                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload))
+                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
                     .to.emit(service, 'InterchainTokenDeployed')
                     .withArgs(tokenId, expectedTokenAddress, AddressZero, tokenName, tokenSymbol, tokenDecimals)
                     .and.to.emit(service, 'TokenManagerDeployed')
@@ -137,18 +137,18 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x1695DD538BeDd759BE212Ed24f809eA51dbc08D0';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const payload = defaultAbiCoder.encode(
-                    ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
-                    [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, tokenName, tokenSymbol, tokenDecimals, minter],
-                );
-                const wrappedPayload = defaultAbiCoder.encode(
-                    ['uint256', 'string', 'bytes'],
-                    [MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload],
-                );
+                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
+                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                    tokenId,
+                    tokenName,
+                    tokenSymbol,
+                    tokenDecimals,
+                    minter,
+                ]);
 
-                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload);
+                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
-                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload))
+                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
                     .to.emit(service, 'InterchainTokenDeployed')
                     .withArgs(tokenId, expectedTokenAddress, minter, tokenName, tokenSymbol, tokenDecimals)
                     .and.to.emit(service, 'TokenManagerDeployed')
@@ -165,18 +165,18 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x123908f4742664f68db857c6a10c846fb557AF08';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const payload = defaultAbiCoder.encode(
-                    ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
-                    [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, tokenName, tokenSymbol, tokenDecimals, '0x'],
-                );
-                const wrappedPayload = defaultAbiCoder.encode(
-                    ['uint256', 'string', 'bytes'],
-                    [MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload],
-                );
+                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
+                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                    tokenId,
+                    tokenName,
+                    tokenSymbol,
+                    tokenDecimals,
+                    '0x',
+                ]);
 
-                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload);
+                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
-                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload))
+                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
                     .to.emit(service, 'InterchainTokenDeployed')
                     .withArgs(tokenId, expectedTokenAddress, minter, tokenName, tokenSymbol, tokenDecimals)
                     .and.to.emit(service, 'TokenManagerDeployed')
@@ -192,18 +192,18 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x43eb02B89a4478128Df888260254efFd75b6D2eA';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const payload = defaultAbiCoder.encode(
-                    ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
-                    [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, tokenName, tokenSymbol, tokenDecimals, minter],
-                );
-                const wrappedPayload = defaultAbiCoder.encode(
-                    ['uint256', 'string', 'bytes'],
-                    [MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload],
-                );
+                const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
+                    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                    tokenId,
+                    tokenName,
+                    tokenSymbol,
+                    tokenDecimals,
+                    minter,
+                ]);
 
-                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload);
+                const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
-                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload))
+                await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
                     .to.emit(service, 'InterchainTokenDeployed')
                     .withArgs(tokenId, expectedTokenAddress, minter, tokenName, tokenSymbol, tokenDecimals)
                     .and.to.emit(service, 'TokenManagerDeployed')

--- a/test/AddressDerivation.js
+++ b/test/AddressDerivation.js
@@ -9,7 +9,14 @@ const {
 } = ethers;
 const { deployAll } = require('../scripts/deploy');
 const { approveContractCall } = require('../scripts/utils');
-const { getRandomBytes32, getSaltFromKey, isHardhat, getContractJSON, encodeDeployInterchainToken } = require('./utils');
+const {
+    getRandomBytes32,
+    getSaltFromKey,
+    isHardhat,
+    getContractJSON,
+    encodeDeployInterchainTokenMessage,
+    encodeHubMessage,
+} = require('./utils');
 const { create3DeployContract } = require('@axelar-network/axelar-gmp-sdk-solidity');
 const Token = getContractJSON('TestInterchainTokenStandard');
 const { NATIVE_INTERCHAIN_TOKEN, MESSAGE_TYPE_RECEIVE_FROM_HUB, ITS_HUB_ADDRESS, ITS_HUB_CHAIN } = require('./constants');
@@ -57,15 +64,8 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x3B058fE7Ed045f56F0152AED1e8c5fbaE7e23C70';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeDeployInterchainToken(
-                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
-                    sourceChain,
-                    tokenId,
-                    tokenName,
-                    tokenSymbol,
-                    tokenDecimals,
-                    minter,
-                );
+                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
+                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -85,15 +85,8 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x89AF99D9373722De5F29ABbF706efeD020ae3E1F';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeDeployInterchainToken(
-                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
-                    sourceChain,
-                    tokenId,
-                    tokenName,
-                    tokenSymbol,
-                    tokenDecimals,
-                    minter,
-                );
+                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
+                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -133,16 +126,8 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x1695DD538BeDd759BE212Ed24f809eA51dbc08D0';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeDeployInterchainToken(
-                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
-                    sourceChain,
-                    tokenId,
-                    tokenName,
-                    tokenSymbol,
-                    tokenDecimals,
-                    minter,
-                );
-
+                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
+                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -162,16 +147,8 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x123908f4742664f68db857c6a10c846fb557AF08';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeDeployInterchainToken(
-                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
-                    sourceChain,
-                    tokenId,
-                    tokenName,
-                    tokenSymbol,
-                    tokenDecimals,
-                    '0x',
-                );
-
+                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, '0x');
+                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -190,16 +167,8 @@ if (isHardhat) {
                 const expectedTokenManagerAddress = '0x43eb02B89a4478128Df888260254efFd75b6D2eA';
 
                 const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, expectedTokenAddress]);
-                const { payload } = encodeDeployInterchainToken(
-                    MESSAGE_TYPE_RECEIVE_FROM_HUB,
-                    sourceChain,
-                    tokenId,
-                    tokenName,
-                    tokenSymbol,
-                    tokenDecimals,
-                    minter,
-                );
-
+                const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
+                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -15,7 +15,7 @@ const {
     expectRevert,
     gasReporter,
     encodeDeployInterchainTokenMessage,
-    encodeHubMessage,
+    encodeSendHubMessage,
     encodeLinkTokenMessage,
 } = require('./utils');
 const {
@@ -29,7 +29,6 @@ const {
     LOCK_UNLOCK_FEE_ON_TRANSFER,
     ITS_HUB_CHAIN,
     ITS_HUB_ADDRESS,
-    MESSAGE_TYPE_SEND_TO_HUB,
     DEPLOY_REMOTE_INTERCHAIN_TOKEN,
     DEPLOY_REMOTE_INTERCHAIN_TOKEN_WITH_ORIGINAL_CHAIN_NAME_AND_MINTER,
     DEPLOY_REMOTE_CANONICAL_INTERCHAIN_TOKEN,
@@ -144,8 +143,10 @@ describe('InterchainTokenFactory', () => {
 
         it('Should initiate a remote interchain token deployment with no original chain name provided', async () => {
             const gasValue = 1234;
-            const message = encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, '0x'),
+            );
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_CANONICAL_INTERCHAIN_TOKEN_WITH_ORIGINAL_CHAIN]('', token.address, destinationChain, gasValue, {
@@ -174,8 +175,10 @@ describe('InterchainTokenFactory', () => {
 
         it('Should initiate a remote interchain token deployment', async () => {
             const gasValue = 1234;
-            const message = encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, '0x'),
+            );
 
             await expectRevert(
                 (gasOptions) =>
@@ -346,8 +349,10 @@ describe('InterchainTokenFactory', () => {
                 .and.to.emit(token, 'RolesAdded')
                 .withArgs(tokenManager.address, 1 << MINTER_ROLE);
 
-            const message = encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, wallet.address.toLowerCase());
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, wallet.address.toLowerCase()),
+            );
 
             await expectRevert(
                 (gasOptions) =>
@@ -527,8 +532,10 @@ describe('InterchainTokenFactory', () => {
                 .and.to.emit(tokenManager, 'RolesRemoved')
                 .withArgs(tokenFactory.address, 1 << FLOW_LIMITER_ROLE);
 
-            const message = encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, '0x'),
+            );
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_INTERCHAIN_TOKEN_WITH_ORIGINAL_CHAIN_NAME_AND_MINTER](
@@ -961,8 +968,10 @@ describe('InterchainTokenFactory', () => {
                 const remoteTokenAddress = '0x1234';
                 const minter = '0x5789';
                 const type = LOCK_UNLOCK;
-                const message = encodeLinkTokenMessage(tokenId, type, token.address, remoteTokenAddress, minter);
-                const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+                const { payload, payloadHash } = encodeSendHubMessage(
+                    destinationChain,
+                    encodeLinkTokenMessage(tokenId, type, token.address, remoteTokenAddress, minter),
+                );
                 const tokenManager = await getContractAt('TokenManager', await service.deployedTokenManager(tokenId), wallet);
                 expect(await tokenManager.isOperator(AddressZero)).to.be.true;
                 expect(await tokenManager.isOperator(service.address)).to.be.true;

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -10,7 +10,14 @@ const {
     utils: { defaultAbiCoder, keccak256, toUtf8Bytes, arrayify },
 } = ethers;
 const { deployAll, deployContract } = require('../scripts/deploy');
-const { getRandomBytes32, expectRevert, gasReporter, encodeDeployInterchainToken, encodeLinkToken } = require('./utils');
+const {
+    getRandomBytes32,
+    expectRevert,
+    gasReporter,
+    encodeDeployInterchainTokenMessage,
+    encodeHubMessage,
+    encodeLinkTokenMessage,
+} = require('./utils');
 const {
     NATIVE_INTERCHAIN_TOKEN,
     LOCK_UNLOCK,
@@ -137,15 +144,8 @@ describe('InterchainTokenFactory', () => {
 
         it('Should initiate a remote interchain token deployment with no original chain name provided', async () => {
             const gasValue = 1234;
-            const { payload, payloadHash } = encodeDeployInterchainToken(
-                MESSAGE_TYPE_SEND_TO_HUB,
-                destinationChain,
-                tokenId,
-                name,
-                symbol,
-                decimals,
-                '0x',
-            );
+            const message = encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, '0x');
+            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_CANONICAL_INTERCHAIN_TOKEN_WITH_ORIGINAL_CHAIN]('', token.address, destinationChain, gasValue, {
@@ -174,15 +174,8 @@ describe('InterchainTokenFactory', () => {
 
         it('Should initiate a remote interchain token deployment', async () => {
             const gasValue = 1234;
-            const { payload, payloadHash } = encodeDeployInterchainToken(
-                MESSAGE_TYPE_SEND_TO_HUB,
-                destinationChain,
-                tokenId,
-                name,
-                symbol,
-                decimals,
-                '0x',
-            );
+            const message = encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, '0x');
+            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
 
             await expectRevert(
                 (gasOptions) =>
@@ -353,15 +346,8 @@ describe('InterchainTokenFactory', () => {
                 .and.to.emit(token, 'RolesAdded')
                 .withArgs(tokenManager.address, 1 << MINTER_ROLE);
 
-            const { payload, payloadHash } = encodeDeployInterchainToken(
-                MESSAGE_TYPE_SEND_TO_HUB,
-                destinationChain,
-                tokenId,
-                name,
-                symbol,
-                decimals,
-                wallet.address.toLowerCase(),
-            );
+            const message = encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, wallet.address.toLowerCase());
+            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
 
             await expectRevert(
                 (gasOptions) =>
@@ -541,15 +527,8 @@ describe('InterchainTokenFactory', () => {
                 .and.to.emit(tokenManager, 'RolesRemoved')
                 .withArgs(tokenFactory.address, 1 << FLOW_LIMITER_ROLE);
 
-            const { payload, payloadHash } = encodeDeployInterchainToken(
-                MESSAGE_TYPE_SEND_TO_HUB,
-                destinationChain,
-                tokenId,
-                name,
-                symbol,
-                decimals,
-                '0x',
-            );
+            const message = encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, '0x');
+            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_INTERCHAIN_TOKEN_WITH_ORIGINAL_CHAIN_NAME_AND_MINTER](
@@ -982,16 +961,8 @@ describe('InterchainTokenFactory', () => {
                 const remoteTokenAddress = '0x1234';
                 const minter = '0x5789';
                 const type = LOCK_UNLOCK;
-                const { payload, payloadHash } = encodeLinkToken(
-                    MESSAGE_TYPE_SEND_TO_HUB,
-                    destinationChain,
-                    tokenId,
-                    type,
-                    token.address,
-                    remoteTokenAddress,
-                    minter,
-                );
-
+                const message = encodeLinkTokenMessage(tokenId, type, token.address, remoteTokenAddress, minter);
+                const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
                 const tokenManager = await getContractAt('TokenManager', await service.deployedTokenManager(tokenId), wallet);
                 expect(await tokenManager.isOperator(AddressZero)).to.be.true;
                 expect(await tokenManager.isOperator(service.address)).to.be.true;

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -10,7 +10,7 @@ const {
     utils: { defaultAbiCoder, keccak256, toUtf8Bytes, arrayify },
 } = ethers;
 const { deployAll, deployContract } = require('../scripts/deploy');
-const { getRandomBytes32, expectRevert, gasReporter } = require('./utils');
+const { getRandomBytes32, expectRevert, gasReporter, encodeITSPayload } = require('./utils');
 const {
     MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
     MESSAGE_TYPE_LINK_TOKEN,
@@ -139,14 +139,14 @@ describe('InterchainTokenFactory', () => {
 
         it('Should initiate a remote interchain token deployment with no original chain name provided', async () => {
             const gasValue = 1234;
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
-                [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, name, symbol, decimals, '0x'],
-            );
-            const wrappedPayload = defaultAbiCoder.encode(
-                ['uint256', 'string', 'bytes'],
-                [MESSAGE_TYPE_SEND_TO_HUB, destinationChain, payload],
-            );
+            const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
+                MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                tokenId,
+                name,
+                symbol,
+                decimals,
+                '0x',
+            ]);
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_CANONICAL_INTERCHAIN_TOKEN_WITH_ORIGINAL_CHAIN]('', token.address, destinationChain, gasValue, {
@@ -156,9 +156,9 @@ describe('InterchainTokenFactory', () => {
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), gasValue, wallet.address)
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, gasValue, wallet.address)
                 .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), wrappedPayload);
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, payload);
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_CANONICAL_INTERCHAIN_TOKEN](token.address, destinationChain, gasValue, {
@@ -168,21 +168,21 @@ describe('InterchainTokenFactory', () => {
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), gasValue, wallet.address)
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, gasValue, wallet.address)
                 .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), wrappedPayload);
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, payload);
         });
 
         it('Should initiate a remote interchain token deployment', async () => {
             const gasValue = 1234;
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
-                [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, name, symbol, decimals, '0x'],
-            );
-            const wrappedPayload = defaultAbiCoder.encode(
-                ['uint256', 'string', 'bytes'],
-                [MESSAGE_TYPE_SEND_TO_HUB, destinationChain, payload],
-            );
+            const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
+                MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                tokenId,
+                name,
+                symbol,
+                decimals,
+                '0x',
+            ]);
 
             await expectRevert(
                 (gasOptions) =>
@@ -207,9 +207,9 @@ describe('InterchainTokenFactory', () => {
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), gasValue, wallet.address)
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, gasValue, wallet.address)
                 .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), wrappedPayload);
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, payload);
         });
     });
 
@@ -353,14 +353,14 @@ describe('InterchainTokenFactory', () => {
                 .and.to.emit(token, 'RolesAdded')
                 .withArgs(tokenManager.address, 1 << MINTER_ROLE);
 
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
-                [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, name, symbol, decimals, wallet.address.toLowerCase()],
-            );
-            const wrappedPayload = defaultAbiCoder.encode(
-                ['uint256', 'string', 'bytes'],
-                [MESSAGE_TYPE_SEND_TO_HUB, destinationChain, payload],
-            );
+            const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
+                MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                tokenId,
+                name,
+                symbol,
+                decimals,
+                wallet.address.toLowerCase(),
+            ]);
 
             await expectRevert(
                 (gasOptions) =>
@@ -430,9 +430,9 @@ describe('InterchainTokenFactory', () => {
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, wallet.address.toLowerCase(), destinationChain)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), gasValue, wallet.address)
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, gasValue, wallet.address)
                 .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), wrappedPayload);
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, payload);
 
             await expectRevert(
                 (gasOptions) =>
@@ -505,9 +505,9 @@ describe('InterchainTokenFactory', () => {
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, wallet.address.toLowerCase(), destinationChain)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), gasValue, wallet.address)
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, gasValue, wallet.address)
                 .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), wrappedPayload);
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, payload);
         });
 
         it('Should initiate a remote interchain token deployment without the same minter', async () => {
@@ -540,14 +540,14 @@ describe('InterchainTokenFactory', () => {
                 .and.to.emit(tokenManager, 'RolesRemoved')
                 .withArgs(tokenFactory.address, 1 << FLOW_LIMITER_ROLE);
 
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
-                [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, name, symbol, decimals, '0x'],
-            );
-            const wrappedPayload = defaultAbiCoder.encode(
-                ['uint256', 'string', 'bytes'],
-                [MESSAGE_TYPE_SEND_TO_HUB, destinationChain, payload],
-            );
+            const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
+                MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+                tokenId,
+                name,
+                symbol,
+                decimals,
+                '0x',
+            ]);
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_INTERCHAIN_TOKEN_WITH_ORIGINAL_CHAIN_NAME_AND_MINTER](
@@ -564,9 +564,9 @@ describe('InterchainTokenFactory', () => {
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), gasValue, wallet.address)
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, gasValue, wallet.address)
                 .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), wrappedPayload);
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, payload);
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_INTERCHAIN_TOKEN](salt, destinationChain, gasValue, {
@@ -576,9 +576,9 @@ describe('InterchainTokenFactory', () => {
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), gasValue, wallet.address)
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, gasValue, wallet.address)
                 .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), wrappedPayload);
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, payload);
 
             await expect(
                 tokenFactory.deployRemoteInterchainTokenWithMinter(salt, AddressZero, destinationChain, '0x', gasValue, {
@@ -588,9 +588,9 @@ describe('InterchainTokenFactory', () => {
                 .to.emit(service, 'InterchainTokenDeploymentStarted')
                 .withArgs(tokenId, name, symbol, decimals, '0x', destinationChain)
                 .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), gasValue, wallet.address)
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, gasValue, wallet.address)
                 .and.to.emit(gateway, 'ContractCall')
-                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), wrappedPayload);
+                .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, payload);
         });
 
         it('Should revert when deploying a remote interchain token to self', async () => {
@@ -980,14 +980,14 @@ describe('InterchainTokenFactory', () => {
                 const remoteTokenAddress = '0x1234';
                 const minter = '0x5789';
                 const type = LOCK_UNLOCK;
-                const payload = defaultAbiCoder.encode(
-                    ['uint256', 'bytes32', 'uint256', 'bytes', 'bytes', 'bytes'],
-                    [MESSAGE_TYPE_LINK_TOKEN, tokenId, type, token.address, remoteTokenAddress, minter],
-                );
-                const wrappedPayload = defaultAbiCoder.encode(
-                    ['uint256', 'string', 'bytes'],
-                    [MESSAGE_TYPE_SEND_TO_HUB, destinationChain, payload],
-                );
+                const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
+                    MESSAGE_TYPE_LINK_TOKEN,
+                    tokenId,
+                    type,
+                    token.address,
+                    remoteTokenAddress,
+                    minter,
+                ]);
 
                 const tokenManager = await getContractAt('TokenManager', await service.deployedTokenManager(tokenId), wallet);
                 expect(await tokenManager.isOperator(AddressZero)).to.be.true;
@@ -1013,9 +1013,9 @@ describe('InterchainTokenFactory', () => {
                         minter.toLowerCase(),
                     )
                     .and.to.emit(gasService, 'NativeGasPaidForContractCall')
-                    .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), gasValue, wallet.address)
+                    .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, gasValue, wallet.address)
                     .and.to.emit(gateway, 'ContractCall')
-                    .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, keccak256(wrappedPayload), wrappedPayload);
+                    .withArgs(service.address, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payloadHash, payload);
             });
 
             it('Should revert on a remote custom token manager deployment if the token manager does does not exist', async () => {

--- a/test/InterchainTokenFactory.js
+++ b/test/InterchainTokenFactory.js
@@ -10,10 +10,8 @@ const {
     utils: { defaultAbiCoder, keccak256, toUtf8Bytes, arrayify },
 } = ethers;
 const { deployAll, deployContract } = require('../scripts/deploy');
-const { getRandomBytes32, expectRevert, gasReporter, encodeITSPayload } = require('./utils');
+const { getRandomBytes32, expectRevert, gasReporter, encodeDeployInterchainToken, encodeLinkToken } = require('./utils');
 const {
-    MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
-    MESSAGE_TYPE_LINK_TOKEN,
     NATIVE_INTERCHAIN_TOKEN,
     LOCK_UNLOCK,
     MINTER_ROLE,
@@ -139,14 +137,15 @@ describe('InterchainTokenFactory', () => {
 
         it('Should initiate a remote interchain token deployment with no original chain name provided', async () => {
             const gasValue = 1234;
-            const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
-                MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+            const { payload, payloadHash } = encodeDeployInterchainToken(
+                MESSAGE_TYPE_SEND_TO_HUB,
+                destinationChain,
                 tokenId,
                 name,
                 symbol,
                 decimals,
                 '0x',
-            ]);
+            );
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_CANONICAL_INTERCHAIN_TOKEN_WITH_ORIGINAL_CHAIN]('', token.address, destinationChain, gasValue, {
@@ -175,14 +174,15 @@ describe('InterchainTokenFactory', () => {
 
         it('Should initiate a remote interchain token deployment', async () => {
             const gasValue = 1234;
-            const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
-                MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+            const { payload, payloadHash } = encodeDeployInterchainToken(
+                MESSAGE_TYPE_SEND_TO_HUB,
+                destinationChain,
                 tokenId,
                 name,
                 symbol,
                 decimals,
                 '0x',
-            ]);
+            );
 
             await expectRevert(
                 (gasOptions) =>
@@ -353,14 +353,15 @@ describe('InterchainTokenFactory', () => {
                 .and.to.emit(token, 'RolesAdded')
                 .withArgs(tokenManager.address, 1 << MINTER_ROLE);
 
-            const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
-                MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+            const { payload, payloadHash } = encodeDeployInterchainToken(
+                MESSAGE_TYPE_SEND_TO_HUB,
+                destinationChain,
                 tokenId,
                 name,
                 symbol,
                 decimals,
                 wallet.address.toLowerCase(),
-            ]);
+            );
 
             await expectRevert(
                 (gasOptions) =>
@@ -540,14 +541,15 @@ describe('InterchainTokenFactory', () => {
                 .and.to.emit(tokenManager, 'RolesRemoved')
                 .withArgs(tokenFactory.address, 1 << FLOW_LIMITER_ROLE);
 
-            const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
-                MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
+            const { payload, payloadHash } = encodeDeployInterchainToken(
+                MESSAGE_TYPE_SEND_TO_HUB,
+                destinationChain,
                 tokenId,
                 name,
                 symbol,
                 decimals,
                 '0x',
-            ]);
+            );
 
             await expect(
                 tokenFactory[DEPLOY_REMOTE_INTERCHAIN_TOKEN_WITH_ORIGINAL_CHAIN_NAME_AND_MINTER](
@@ -980,14 +982,15 @@ describe('InterchainTokenFactory', () => {
                 const remoteTokenAddress = '0x1234';
                 const minter = '0x5789';
                 const type = LOCK_UNLOCK;
-                const { payload, payloadHash } = encodeITSPayload(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, [
-                    MESSAGE_TYPE_LINK_TOKEN,
+                const { payload, payloadHash } = encodeLinkToken(
+                    MESSAGE_TYPE_SEND_TO_HUB,
+                    destinationChain,
                     tokenId,
                     type,
                     token.address,
                     remoteTokenAddress,
                     minter,
-                ]);
+                );
 
                 const tokenManager = await getContractAt('TokenManager', await service.deployedTokenManager(tokenId), wallet);
                 expect(await tokenManager.isOperator(AddressZero)).to.be.true;

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -774,7 +774,6 @@ describe('Interchain Token Service', () => {
                 .withArgs(tokenId, tokenAddress, AddressZero, tokenName, tokenSymbol, tokenDecimals)
                 .and.to.emit(service, 'TokenManagerDeployed')
                 .withArgs(tokenId, tokenManagerAddress, NATIVE_INTERCHAIN_TOKEN, params);
-                
             const tokenManager = await getContractAt('TokenManager', tokenManagerAddress, wallet);
             expect(await tokenManager.tokenAddress()).to.equal(tokenAddress);
             expect(await tokenManager.hasRole(service.address, OPERATOR_ROLE)).to.be.true;

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -1491,7 +1491,6 @@ describe('Interchain Token Service', () => {
                 [INVALID_MESSAGE_TYPE, tokenId, destAddress, amount],
             );
             const wrappedPayload = encodeITSWrappedPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload);
-
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload.payload);
 
             await expectRevert(
@@ -1516,7 +1515,6 @@ describe('Interchain Token Service', () => {
                 .encode(['uint256', 'bytes'], [MESSAGE_TYPE_INTERCHAIN_TRANSFER, hexlify(wallet.address)])
                 .slice(0, 32);
             const wrappedPayload = encodeITSWrappedPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, invalidPayload);
-
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload.payload);
 
             await expectRevert(
@@ -1539,7 +1537,6 @@ describe('Interchain Token Service', () => {
                 amount,
                 '0x',
             );
-
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(
@@ -1705,7 +1702,6 @@ describe('Interchain Token Service', () => {
                     sendAmount,
                     '0x',
                 );
-
                 const transferToAddress = tokenManager.address;
 
                 await token.approve(service.address, amount).then((tx) => tx.wait());
@@ -3267,6 +3263,23 @@ describe('Interchain Token Service', () => {
             );
 
             await service.setPauseStatus(false).then((tx) => tx.wait());
+        });
+
+        it('Should revert on invalid message type', async () => {
+            const message = MESSAGE_TYPE_SEND_TO_HUB;
+            const tokenId = HashZero;
+            const payload = defaultAbiCoder.encode(
+                ['uint256', 'bytes32', 'bytes', 'bytes', 'uint256', 'bytes'],
+                [message, tokenId, '0x', '0x', amount, '0x'],
+            );
+            const wrappedPayload = encodeITSWrappedPayload(MESSAGE_TYPE_SEND_TO_HUB, sourceChain, payload);
+
+            await expectRevert(
+                (gasOptions) => service.contractCallValue(ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload.payload, gasOptions),
+                service,
+                'InvalidMessageType',
+                [message],
+            );
         });
 
         it('Should revert on invalid express message type', async () => {

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -1514,15 +1514,12 @@ describe('Interchain Token Service', () => {
             const invalidPayload = defaultAbiCoder
                 .encode(['uint256', 'bytes'], [MESSAGE_TYPE_INTERCHAIN_TRANSFER, hexlify(wallet.address)])
                 .slice(0, 32);
-            const wrappedPayload = defaultAbiCoder.encode(
-                ['uint256', 'string', 'bytes'],
-                [MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, invalidPayload],
-            );
+            const wrappedPayload = encodeITSWrappedPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, invalidPayload);
 
-            const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload);
+            const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload.payload);
 
             await expectRevert(
-                (gasOptions) => service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload, gasOptions),
+                (gasOptions) => service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload.payload, gasOptions),
                 service,
                 'InvalidPayload',
             );
@@ -2223,14 +2220,11 @@ describe('Interchain Token Service', () => {
         it('Should revert with UntrustedChain when receiving a direct message from the ITS Hub. Not supported yet', async () => {
             const data = '0x';
             const payload = defaultAbiCoder.encode(['uint256', 'bytes'], [MESSAGE_TYPE_INTERCHAIN_TRANSFER, data]);
-            const wrappedPayload = defaultAbiCoder.encode(
-                ['uint256', 'string', 'bytes'],
-                [MESSAGE_TYPE_RECEIVE_FROM_HUB, ITS_HUB_CHAIN, payload],
-            );
-            const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload);
+            const wrappedPayload = encodeITSWrappedPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, ITS_HUB_CHAIN, payload);
+            const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload.payload);
 
             await expectRevert(
-                (gasOptions) => service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload, gasOptions),
+                (gasOptions) => service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload.payload, gasOptions),
                 service,
                 'UntrustedChain',
             );
@@ -3289,7 +3283,7 @@ describe('Interchain Token Service', () => {
             const wrappedPayload = encodeITSWrappedPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload);
 
             await expectRevert(
-                (gasOptions) => service.contractCallValue(ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload, gasOptions),
+                (gasOptions) => service.contractCallValue(ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload.payload, gasOptions),
                 service,
                 'InvalidExpressMessageType',
                 [message],

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -21,7 +21,8 @@ const {
     encodeInterchainTransferMessage,
     encodeDeployInterchainTokenMessage,
     encodeDeployTokenManagerMessage,
-    encodeHubMessage,
+    encodeSendHubMessage,
+    encodeReceiveHubMessage,
     encodeLinkTokenMessage,
     encodeRegisterTokenMetadataMessage,
 } = require('./utils');
@@ -29,7 +30,6 @@ const { deployAll, deployContract, deployInterchainTokenService } = require('../
 const {
     MESSAGE_TYPE_INTERCHAIN_TRANSFER,
     MESSAGE_TYPE_DEPLOY_TOKEN_MANAGER,
-    MESSAGE_TYPE_RECEIVE_FROM_HUB,
     INVALID_MESSAGE_TYPE,
     NATIVE_INTERCHAIN_TOKEN,
     MINT_BURN_FROM,
@@ -86,8 +86,10 @@ describe('Interchain Token Service', () => {
         ]);
 
         const params = defaultAbiCoder.encode(['bytes', 'address'], [wallet.address, token.address]);
-        const message = encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter);
-        const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+        const { payload } = encodeReceiveHubMessage(
+            sourceChain,
+            encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter),
+        );
         const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
         const expectedTokenManagerAddress = await service.tokenManagerAddress(tokenId);
 
@@ -152,8 +154,10 @@ describe('Interchain Token Service', () => {
         }
 
         const params = defaultAbiCoder.encode(['bytes', 'address'], [wallet.address, token.address]);
-        const message = encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter);
-        const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+        const { payload } = encodeReceiveHubMessage(
+            sourceChain,
+            encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter),
+        );
         const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
         const expectedTokenManagerAddress = await service.tokenManagerAddress(tokenId);
 
@@ -202,8 +206,10 @@ describe('Interchain Token Service', () => {
             await token.transferMintership(tokenManager.address).then((tx) => tx.wait());
 
             const params = defaultAbiCoder.encode(['bytes', 'address'], [wallet.address, token.address]);
-            const message = encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
             const expectedTokenManagerAddress = await service.tokenManagerAddress(tokenId);
 
@@ -231,8 +237,10 @@ describe('Interchain Token Service', () => {
         const tokenManagerAddress = await service.tokenManagerAddress(tokenId);
         const tokenAddress = await service.interchainTokenAddress(tokenId);
         const params = defaultAbiCoder.encode(['bytes', 'address'], [wallet.address, tokenAddress]);
-        const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, wallet.address);
-        const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+        const { payload } = encodeReceiveHubMessage(
+            sourceChain,
+            encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, wallet.address),
+        );
         const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
         await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -765,8 +773,10 @@ describe('Interchain Token Service', () => {
             const operator = '0x';
             const tokenAddress = await service.interchainTokenAddress(tokenId);
             const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, tokenAddress]);
-            const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, destinationChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                destinationChain,
+                encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -805,8 +815,10 @@ describe('Interchain Token Service', () => {
             const tokenId = getRandomBytes32();
             const minter = wallet.address;
             const commandId = getRandomBytes32();
-            const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, destinationChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                destinationChain,
+                encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter),
+            );
 
             await expectRevert(
                 (gasOptions) => service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload, gasOptions),
@@ -822,8 +834,10 @@ describe('Interchain Token Service', () => {
             const operator = '0x';
             const tokenAddress = await service.interchainTokenAddress(tokenId);
             const params = defaultAbiCoder.encode(['bytes', 'address'], [operator, tokenAddress]);
-            const message = encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, destinationChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                destinationChain,
+                encodeDeployInterchainTokenMessage(tokenId, tokenName, tokenSymbol, tokenDecimals, minter),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -959,8 +973,10 @@ describe('Interchain Token Service', () => {
             const remoteTokenAddress = '0x1234';
             const minter = '0x5789';
             const type = LOCK_UNLOCK;
-            const message = encodeLinkTokenMessage(tokenId, type, tokenAddress, remoteTokenAddress, minter);
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeLinkTokenMessage(tokenId, type, tokenAddress, remoteTokenAddress, minter),
+            );
 
             await expect(
                 reportGas(
@@ -1040,8 +1056,10 @@ describe('Interchain Token Service', () => {
             ]);
 
             const params = defaultAbiCoder.encode(['bytes', 'address'], [wallet.address, token.address]);
-            const message = encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
             const expectedTokenManagerAddress = await service.tokenManagerAddress(tokenId);
 
@@ -1070,8 +1088,10 @@ describe('Interchain Token Service', () => {
             ]);
 
             const params = defaultAbiCoder.encode(['bytes', 'address'], [wallet.address, token.address]);
-            const message = encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             const expectedTokenManagerAddress = await service.tokenManagerAddress(tokenId);
@@ -1097,8 +1117,10 @@ describe('Interchain Token Service', () => {
                 tokenId,
             ]);
 
-            const message = encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeLinkTokenMessage(tokenId, tokenManagerType, sourceTokenAddress, token.address, minter),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expectRevert(
@@ -1130,8 +1152,10 @@ describe('Interchain Token Service', () => {
                 'free',
             );
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const transferToAddress = tokenManager.address;
 
             await expect(service[INTERCHAIN_TRANSFER](...[tokenId, destinationChain, destAddress, amount, { value: gasValue }]))
@@ -1156,8 +1180,10 @@ describe('Interchain Token Service', () => {
                 'free',
             );
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const transferToAddress = tokenManager.address;
 
             await expect(
@@ -1396,7 +1422,7 @@ describe('Interchain Token Service', () => {
                 ['uint256', 'bytes32', 'bytes', 'uint256'],
                 [INVALID_MESSAGE_TYPE, tokenId, destAddress, amount],
             );
-            const wrappedPayload = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload);
+            const wrappedPayload = encodeReceiveHubMessage(sourceChain, payload);
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload.payload);
 
             await expectRevert(
@@ -1420,7 +1446,7 @@ describe('Interchain Token Service', () => {
             const invalidPayload = defaultAbiCoder
                 .encode(['uint256', 'bytes'], [MESSAGE_TYPE_INTERCHAIN_TRANSFER, hexlify(wallet.address)])
                 .slice(0, 32);
-            const wrappedPayload = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, invalidPayload);
+            const wrappedPayload = encodeReceiveHubMessage(sourceChain, invalidPayload);
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload.payload);
 
             await expectRevert(
@@ -1434,8 +1460,10 @@ describe('Interchain Token Service', () => {
             const [token, tokenManager, tokenId] = await deployFunctions.lockUnlock(service, 'Test Token Lock Unlock', 'TT', 12, amount);
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(
@@ -1452,8 +1480,10 @@ describe('Interchain Token Service', () => {
 
         it('Should be able to receive mint/burn token', async () => {
             const [token, , tokenId] = await deployFunctions.mintBurn(service, 'Test Token Mint Burn', 'TT', 12, 0);
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(
@@ -1475,8 +1505,10 @@ describe('Interchain Token Service', () => {
             );
             await token.transfer(tokenManager.address, amount + 10).then((tx) => tx.wait());
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -1498,8 +1530,10 @@ describe('Interchain Token Service', () => {
             );
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -1526,8 +1560,10 @@ describe('Interchain Token Service', () => {
             it(`Should initiate an interchain token transfer via the interchainTransfer standard contract call & express call [${type}]`, async () => {
                 const [token, tokenManager, tokenId] = await deployFunctions[type](service, `Test Token ${type}`, 'TT', 12, amount * 2);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
-                const message = encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, sendAmount, '0x');
-                const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+                const { payload, payloadHash } = encodeSendHubMessage(
+                    destinationChain,
+                    encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, sendAmount, '0x'),
+                );
                 let transferToAddress = AddressZero;
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
@@ -1562,8 +1598,10 @@ describe('Interchain Token Service', () => {
             it(`Should be able to initiate an interchain token transfer via the interchainTransfer function on the service when the service is approved as well [${type}]`, async () => {
                 const [token, tokenManager, tokenId] = await deployFunctions[type](service, `Test Token ${type}`, 'TT', 12, amount);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
-                const message = encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, sendAmount, '0x');
-                const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+                const { payload, payloadHash } = encodeSendHubMessage(
+                    destinationChain,
+                    encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, sendAmount, '0x'),
+                );
                 const transferToAddress = tokenManager.address;
 
                 await token.approve(service.address, amount).then((tx) => tx.wait());
@@ -1588,8 +1626,10 @@ describe('Interchain Token Service', () => {
             const type = 'lockUnlock';
             const metadata = '0x00000000';
             const [token, tokenManager, tokenId] = await deployFunctions[type](service, `Test Token ${type}`, 'TT', 12, amount);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, amount, '0x'),
+            );
             const transferToAddress = tokenManager.address;
 
             await expect(
@@ -1621,8 +1661,10 @@ describe('Interchain Token Service', () => {
         it('Should initiate an interchain token transfer via the callContractWithInterchainToken function on the service', async () => {
             const type = 'lockUnlock';
             const [token, tokenManager, tokenId] = await deployFunctions[type](service, `Test Token ${type}`, 'TT', 12, amount);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, amount, data);
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, amount, data),
+            );
             const transferToAddress = tokenManager.address;
 
             await expect(
@@ -1645,8 +1687,10 @@ describe('Interchain Token Service', () => {
             const type = 'mintBurn';
             const [token, , tokenId] = await deployFunctions[type](service, `Test Token ${type}`, 'TT', 12, amount);
             const largeData = hexlify(randomBytes(8 * 1024)); // 8 KB
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, amount, largeData);
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, amount, largeData),
+            );
             const transferToAddress = AddressZero;
 
             await expect(
@@ -1773,8 +1817,10 @@ describe('Interchain Token Service', () => {
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
             const msg = 'lock/unlock';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -1795,8 +1841,10 @@ describe('Interchain Token Service', () => {
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
 
             const data = '0x';
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -1812,8 +1860,10 @@ describe('Interchain Token Service', () => {
 
             const msg = 'mint/burn';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(
@@ -1836,11 +1886,12 @@ describe('Interchain Token Service', () => {
 
         it('Should be able to receive mint/burn from token', async () => {
             const [token, , tokenId] = await deployFunctions.mintBurnFrom(service, 'Test Token Mint Burn From', 'TT', 12, amount);
-
             const msg = 'mint/burn';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(
@@ -1872,8 +1923,10 @@ describe('Interchain Token Service', () => {
             await token.transfer(tokenManager.address, amount + 10).then((tx) => tx.wait());
             const msg = 'lock/unlock';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
@@ -1892,10 +1945,13 @@ describe('Interchain Token Service', () => {
         it('Should revert if token handler transfer token from fails', async () => {
             const [token, tokenManager, tokenId] = await deployFunctions.lockUnlock(service, 'Test Token Lock Unlock', 'TT', 12, amount);
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
+
             const msg = 'lock/unlock';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, AddressZero, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, AddressZero, amount, data),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             const errorSignatureHash = id('TokenTransferFailed()');
@@ -1912,10 +1968,13 @@ describe('Interchain Token Service', () => {
         it('Should revert if execute with interchain token fails', async () => {
             const [token, tokenManager, tokenId] = await deployFunctions.lockUnlock(service, 'Test Token Lock Unlock', 'TT', 12, amount);
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
+
             const msg = 'lock/unlock';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, invalidExecutable.address, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, invalidExecutable.address, amount, data),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expectRevert(
@@ -1928,10 +1987,7 @@ describe('Interchain Token Service', () => {
 
         it('Should revert with UntrustedChain when the message type is RECEIVE_FROM_HUB and untrusted original source chain', async () => {
             const data = '0x';
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'string', 'bytes'],
-                [MESSAGE_TYPE_RECEIVE_FROM_HUB, 'untrustedSourceChain', data],
-            );
+            const { payload } = encodeReceiveHubMessage('untrustedSourceChain', data);
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expectRevert(
@@ -1947,10 +2003,7 @@ describe('Interchain Token Service', () => {
             const invalidItsMessage = defaultAbiCoder
                 .encode(['uint256', 'uint256', 'bytes'], [MESSAGE_TYPE_INTERCHAIN_TRANSFER, amount, data])
                 .slice(0, 32);
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'string', 'bytes'],
-                [MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, invalidItsMessage],
-            );
+            const { payload } = encodeReceiveHubMessage(sourceChain, invalidItsMessage);
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expect(service.setTrustedChain(sourceChain)).to.emit(service, 'TrustedChainSet').withArgs(sourceChain);
@@ -1983,8 +2036,10 @@ describe('Interchain Token Service', () => {
             const remoteTokenAddress = '0x1234';
             const type = LOCK_UNLOCK;
             const sourceChain = 'hub chain 1';
-            const message = encodeLinkTokenMessage(tokenId, type, remoteTokenAddress, token.address, minter);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeLinkTokenMessage(tokenId, type, remoteTokenAddress, token.address, minter),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
             const expectedTokenManagerAddress = await service.tokenManagerAddress(tokenId);
 
@@ -2002,7 +2057,7 @@ describe('Interchain Token Service', () => {
         it('Should revert with UntrustedChain when receiving a direct message from the ITS Hub. Not supported yet', async () => {
             const data = '0x';
             const payload = defaultAbiCoder.encode(['uint256', 'bytes'], [MESSAGE_TYPE_INTERCHAIN_TRANSFER, data]);
-            const wrappedPayload = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, ITS_HUB_CHAIN, payload);
+            const wrappedPayload = encodeReceiveHubMessage(ITS_HUB_CHAIN, payload);
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload.payload);
 
             await expectRevert(
@@ -2023,8 +2078,10 @@ describe('Interchain Token Service', () => {
             it(`Should be able to initiate an interchain token transfer via interchainTransfer & interchainTransferFrom [${type}]`, async () => {
                 [token, tokenManager, tokenId] = await deployFunctions[type](service, `Test Token ${type}`, 'TT', 12, amount * 3, true);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
-                const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, sendAmount, '0x');
-                const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+                const { payload, payloadHash } = encodeSendHubMessage(
+                    destinationChain,
+                    encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, sendAmount, '0x'),
+                );
                 let transferToAddress = AddressZero;
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
@@ -2068,8 +2125,10 @@ describe('Interchain Token Service', () => {
             it(`Should be able to initiate an interchain token transfer via interchainTransfer [${type}] without native gas`, async () => {
                 [token, tokenManager, tokenId] = await deployFunctions[type](service, `Test Token ${type}`, 'TT', 12, amount * 3, true);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
-                const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, sendAmount, '0x');
-                const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+                const { payload, payloadHash } = encodeSendHubMessage(
+                    destinationChain,
+                    encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, sendAmount, '0x'),
+                );
                 let transferToAddress = AddressZero;
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
@@ -2093,8 +2152,10 @@ describe('Interchain Token Service', () => {
 
         it('Should be able to initiate an interchain token transfer using interchainTransferFrom with max possible allowance', async () => {
             const sendAmount = amount;
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, sendAmount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+            const { payload, payloadHash } = encodeSendHubMessage(
+                destinationChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, sendAmount, '0x'),
+            );
             const transferToAddress = tokenManager.address;
             const sender = wallet;
             const spender = otherWallet;
@@ -2149,8 +2210,10 @@ describe('Interchain Token Service', () => {
             it(`Should be able to initiate an interchain token transfer [${type}]`, async () => {
                 const [token, tokenManager, tokenId] = await deployFunctions[type](service, `Test Token ${type}`, 'TT', 12, amount, false);
                 const sendAmount = type === 'lockUnlockFee' ? amount - 10 : amount;
-                const message = encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, sendAmount, data);
-                const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, destinationChain, message);
+                const { payload, payloadHash } = encodeSendHubMessage(
+                    destinationChain,
+                    encodeInterchainTransferMessage(tokenId, sourceAddress, destAddress, sendAmount, data),
+                );
                 let transferToAddress = AddressZero;
 
                 if (type === 'lockUnlock' || type === 'lockUnlockFee') {
@@ -2247,8 +2310,10 @@ describe('Interchain Token Service', () => {
         });
 
         it('Should express execute', async () => {
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destinationAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destinationAddress, amount, '0x'),
+            );
 
             await expect(service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
                 .to.emit(service, 'ExpressExecuted')
@@ -2258,8 +2323,10 @@ describe('Interchain Token Service', () => {
         });
 
         it('Should revert on express execute if token handler transfer token from fails', async () => {
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddress, AddressZero, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddress, AddressZero, amount, data),
+            );
 
             const errorSignatureHash = id('TokenTransferFailed()');
             const errorData = errorSignatureHash.substring(0, 10);
@@ -2273,8 +2340,10 @@ describe('Interchain Token Service', () => {
         });
 
         it('Should revert on express execute with token if token transfer fails on destination chain', async () => {
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddress, invalidExecutable.address, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddress, invalidExecutable.address, amount, data),
+            );
 
             await expectRevert(
                 (gasOptions) => service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload, gasOptions),
@@ -2285,8 +2354,10 @@ describe('Interchain Token Service', () => {
         });
 
         it('Should express execute with token', async () => {
-            const itsMessage = encodeInterchainTransferMessage(tokenId, sourceAddress, executable.address, amount, data);
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, itsMessage);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddress, executable.address, amount, data),
+            );
 
             await expect(service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload))
                 .to.emit(service, 'ExpressExecuted')
@@ -2359,15 +2430,10 @@ describe('Interchain Token Service', () => {
         });
 
         it('Should revert on express execute when service is paused', async () => {
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'bytes', 'bytes', 'uint256', 'bytes'],
-                [MESSAGE_TYPE_INTERCHAIN_TRANSFER, tokenId, hexlify(wallet.address), destinationAddress, amount, '0x'],
-            );
-
             await service.setPauseStatus(true).then((tx) => tx.wait());
 
             await expectRevert(
-                (gasOptions) => service.expressExecute(commandId, sourceChain, sourceAddress, payload, gasOptions),
+                (gasOptions) => service.expressExecute(commandId, sourceChain, sourceAddress, '0x', gasOptions),
                 service,
                 'Pause',
             );
@@ -2389,8 +2455,10 @@ describe('Interchain Token Service', () => {
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
             await token.approve(service.address, amount).then((tx) => tx.wait());
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expectRevert(
@@ -2404,8 +2472,7 @@ describe('Interchain Token Service', () => {
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
             await token.approve(service.address, amount).then((tx) => tx.wait());
 
-            const message = encodeDeployTokenManagerMessage(tokenId, destAddress, amount);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(sourceChain, encodeDeployTokenManagerMessage(tokenId, destAddress, amount));
             const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expectRevert(
@@ -2420,8 +2487,10 @@ describe('Interchain Token Service', () => {
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
             await token.approve(service.address, amount).then((tx) => tx.wait());
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
 
             const commandId = getRandomBytes32();
             await service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload).then((tx) => tx.wait());
@@ -2440,8 +2509,10 @@ describe('Interchain Token Service', () => {
             await (await token.mint(wallet.address, amount)).wait();
             await (await token.approve(service.address, amount)).wait();
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = getRandomBytes32();
 
             await (await service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload)).wait();
@@ -2460,8 +2531,10 @@ describe('Interchain Token Service', () => {
 
             await token.approve(service.address, amount).then((tx) => tx.wait());
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = getRandomBytes32();
 
             await service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload).then((tx) => tx.wait());
@@ -2481,8 +2554,10 @@ describe('Interchain Token Service', () => {
 
             await token.approve(service.address, amount).then((tx) => tx.wait());
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = getRandomBytes32();
 
             await service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload).then((tx) => tx.wait());
@@ -2508,8 +2583,10 @@ describe('Interchain Token Service', () => {
             await token.transfer(tokenManager.address, amount + 10).then((tx) => tx.wait());
             await token.approve(service.address, amount).then((tx) => tx.wait());
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = getRandomBytes32();
 
             await service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload).then((tx) => tx.wait());
@@ -2537,8 +2614,10 @@ describe('Interchain Token Service', () => {
             await token.transfer(tokenManager.address, amount).then((tx) => tx.wait());
             await token.approve(service.address, amount).then((tx) => tx.wait());
 
-            const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x');
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), destAddress, amount, '0x'),
+            );
             const commandId = getRandomBytes32();
 
             await service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload).then((tx) => tx.wait());
@@ -2580,8 +2659,10 @@ describe('Interchain Token Service', () => {
 
             const msg = 'lock/unlock';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data);
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data),
+            );
             const commandId = getRandomBytes32();
 
             await service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload).then((tx) => tx.wait());
@@ -2605,8 +2686,10 @@ describe('Interchain Token Service', () => {
 
             const msg = 'mint/burn';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data);
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data),
+            );
             const commandId = getRandomBytes32();
 
             await (await service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload)).wait();
@@ -2627,8 +2710,10 @@ describe('Interchain Token Service', () => {
 
             const msg = 'mint/burn';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data);
-            const { payload, payloadHash } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload, payloadHash } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data),
+            );
             const commandId = getRandomBytes32();
 
             await service.expressExecute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload).then((tx) => tx.wait());
@@ -2656,8 +2741,10 @@ describe('Interchain Token Service', () => {
 
             const msg = 'lock/unlock';
             const data = defaultAbiCoder.encode(['address', 'string'], [wallet.address, msg]);
-            const message = encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data);
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(
+                sourceChain,
+                encodeInterchainTransferMessage(tokenId, sourceAddressForService, destAddress, amount, data),
+            );
             const commandId = await approveContractCall(gateway, sourceChain, sourceAddress, service.address, payload);
 
             await expect(service.expressExecute(commandId, sourceChain, sourceAddress, payload)).to.be.reverted;
@@ -2703,8 +2790,10 @@ describe('Interchain Token Service', () => {
             expect(flowOut).to.eq(sendAmount);
 
             async function receiveToken(amount) {
-                const message = encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), wallet.address, amount, '0x');
-                const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+                const { payload } = encodeReceiveHubMessage(
+                    sourceChain,
+                    encodeInterchainTransferMessage(tokenId, hexlify(wallet.address), wallet.address, amount, '0x'),
+                );
                 const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
                 return service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload);
@@ -2911,7 +3000,7 @@ describe('Interchain Token Service', () => {
                 ['uint256', 'bytes32', 'bytes', 'bytes', 'uint256', 'bytes'],
                 [message, tokenId, '0x', '0x', amount, '0x'],
             );
-            const wrappedPayload = encodeHubMessage(MESSAGE_TYPE_SEND_TO_HUB, sourceChain, payload);
+            const wrappedPayload = encodeSendHubMessage(sourceChain, payload);
 
             await expectRevert(
                 (gasOptions) => service.contractCallValue(ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload.payload, gasOptions),
@@ -2928,7 +3017,7 @@ describe('Interchain Token Service', () => {
                 ['uint256', 'bytes32', 'bytes', 'bytes', 'uint256', 'bytes'],
                 [message, tokenId, '0x', '0x', amount, '0x'],
             );
-            const wrappedPayload = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload);
+            const wrappedPayload = encodeReceiveHubMessage(sourceChain, payload);
 
             await expectRevert(
                 (gasOptions) => service.contractCallValue(ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload.payload, gasOptions),
@@ -2941,8 +3030,7 @@ describe('Interchain Token Service', () => {
         it('Should return correct token address and amount', async () => {
             const mintAmount = 1234;
             const [token, , tokenId] = await deployFunctions.lockUnlock(service, 'Test Token Lock Unlock', 'TT', 12, mintAmount);
-            const message = encodeInterchainTransferMessage(tokenId, '0x', '0x', amount, '0x');
-            const { payload } = encodeHubMessage(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, message);
+            const { payload } = encodeReceiveHubMessage(sourceChain, encodeInterchainTransferMessage(tokenId, '0x', '0x', amount, '0x'));
             const [tokenAddress, returnedAmount] = await service.contractCallValue(ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload);
 
             expect(tokenAddress).to.eq(token.address);

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -1466,19 +1466,17 @@ describe('Interchain Token Service', () => {
         it('Should revert on execute with invalid messageType', async () => {
             const tokenId = getRandomBytes32();
 
-            const payload = defaultAbiCoder.encode(
-                ['uint256', 'bytes32', 'bytes', 'uint256'],
-                [INVALID_MESSAGE_TYPE, tokenId, destAddress, amount],
-            );
-            const wrappedPayload = defaultAbiCoder.encode(
-                ['uint256', 'string', 'bytes'],
-                [MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload],
-            );
+            const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
+                INVALID_MESSAGE_TYPE,
+                tokenId,
+                destAddress,
+                amount,
+            ]);
 
-            const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload);
+            const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
 
             await expectRevert(
-                (gasOptions) => service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload, gasOptions),
+                (gasOptions) => service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload, gasOptions),
                 service,
                 'InvalidMessageType',
                 [INVALID_MESSAGE_TYPE],

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -1466,16 +1466,19 @@ describe('Interchain Token Service', () => {
         it('Should revert on execute with invalid messageType', async () => {
             const tokenId = getRandomBytes32();
 
-            const { payload } = encodeITSPayload(MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, [
-                INVALID_MESSAGE_TYPE,
-                tokenId,
-                destAddress,
-                amount,
-            ]);
-            const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, payload);
+            const payload = defaultAbiCoder.encode(
+                ['uint256', 'bytes32', 'bytes', 'uint256'],
+                [INVALID_MESSAGE_TYPE, tokenId, destAddress, amount],
+            );
+            const wrappedPayload = defaultAbiCoder.encode(
+                ['uint256', 'string', 'bytes'],
+                [MESSAGE_TYPE_RECEIVE_FROM_HUB, sourceChain, payload],
+            );
+
+            const commandId = await approveContractCall(gateway, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, service.address, wrappedPayload);
 
             await expectRevert(
-                (gasOptions) => service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, payload, gasOptions),
+                (gasOptions) => service.execute(commandId, ITS_HUB_CHAIN, ITS_HUB_ADDRESS, wrappedPayload, gasOptions),
                 service,
                 'InvalidMessageType',
                 [INVALID_MESSAGE_TYPE],

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -2639,14 +2639,9 @@ describe('Interchain Token Service', () => {
         });
 
         it('Should revert on express execute when service is paused', async () => {
-            const { payload } = encodeInterchainTransfer(
-                MESSAGE_TYPE_RECEIVE_FROM_HUB,
-                sourceChain,
-                tokenId,
-                hexlify(wallet.address),
-                destinationAddress,
-                amount,
-                '0x',
+            const payload = defaultAbiCoder.encode(
+                ['uint256', 'bytes32', 'bytes', 'bytes', 'uint256', 'bytes'],
+                [MESSAGE_TYPE_INTERCHAIN_TRANSFER, tokenId, hexlify(wallet.address), destinationAddress, amount, '0x'],
             );
 
             await service.setPauseStatus(true).then((tx) => tx.wait());

--- a/test/InterchainTokenService.js
+++ b/test/InterchainTokenService.js
@@ -270,6 +270,7 @@ describe('Interchain Token Service', () => {
             .withArgs(tokenId, tokenAddress, wallet.address, tokenName, tokenSymbol, tokenDecimals)
             .and.to.emit(service, 'TokenManagerDeployed')
             .withArgs(tokenId, tokenManagerAddress, NATIVE_INTERCHAIN_TOKEN, params);
+
         const tokenManager = await getContractAt('TokenManager', tokenManagerAddress, wallet);
         expect(await tokenManager.tokenAddress()).to.equal(tokenAddress);
         expect(await tokenManager.hasRole(service.address, OPERATOR_ROLE)).to.be.true;

--- a/test/utils.js
+++ b/test/utils.js
@@ -9,6 +9,8 @@ const {
     MESSAGE_TYPE_INTERCHAIN_TRANSFER,
     MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN,
     MESSAGE_TYPE_DEPLOY_TOKEN_MANAGER,
+    MESSAGE_TYPE_SEND_TO_HUB,
+    MESSAGE_TYPE_RECEIVE_FROM_HUB,
     MESSAGE_TYPE_LINK_TOKEN,
     MESSAGE_TYPE_REGISTER_TOKEN_METADATA,
 } = require('./constants');
@@ -212,8 +214,16 @@ function encodeDeployTokenManagerMessage(tokenId, address, salt) {
     return defaultAbiCoder.encode(['uint256', 'bytes32', 'bytes', 'uint256'], [MESSAGE_TYPE_DEPLOY_TOKEN_MANAGER, tokenId, address, salt]);
 }
 
-function encodeHubMessage(wrapperType, chain, message) {
-    const payload = defaultAbiCoder.encode(['uint256', 'string', 'bytes'], [wrapperType, chain, message]);
+function encodeSendHubMessage(chain, message) {
+    const payload = defaultAbiCoder.encode(['uint256', 'string', 'bytes'], [MESSAGE_TYPE_SEND_TO_HUB, chain, message]);
+    return {
+        payload,
+        payloadHash: keccak256(payload),
+    };
+}
+
+function encodeReceiveHubMessage(chain, message) {
+    const payload = defaultAbiCoder.encode(['uint256', 'string', 'bytes'], [MESSAGE_TYPE_RECEIVE_FROM_HUB, chain, message]);
     return {
         payload,
         payloadHash: keccak256(payload),
@@ -251,7 +261,8 @@ module.exports = {
     encodeInterchainTransferMessage,
     encodeDeployInterchainTokenMessage,
     encodeDeployTokenManagerMessage,
-    encodeHubMessage,
+    encodeSendHubMessage,
+    encodeReceiveHubMessage,
     encodeLinkTokenMessage,
     encodeRegisterTokenMetadataMessage,
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -195,7 +195,7 @@ function getContractJSON(contractName, artifactPath) {
     }
 }
 
-function resolveITSMessageType(messageType, values) {
+function resolveMessageType(messageType, values) {
     switch (messageType) {
         case MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN:
             if (values.length === 7) {
@@ -242,7 +242,7 @@ function wrapPayload(wrapperType, chain, payload) {
  * @returns {{ payload: string, hash: string } | { payload: string, hash: string }[]} - Wrapped payload(s) and hash(es)
  */
 function encodeITSPayload(wrapperType, chain, values) {
-    const messageType = resolveITSMessageType(values[0], values);
+    const messageType = resolveMessageType(values[0], values);
     const payload = defaultAbiCoder.encode(messageType, values);
 
     if (Array.isArray(chain)) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -194,63 +194,45 @@ function getContractJSON(contractName, artifactPath) {
     }
 }
 
-function encodeDeployInterchainToken(wrapperType, chain, tokenId, name, symbol, decimals, minter, operator = null) {
-    const values = operator
-        ? [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, name, symbol, decimals, minter, operator]
-        : [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, name, symbol, decimals, minter];
-    const types = operator
-        ? ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes', 'bytes']
-        : ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'];
-    const payload = defaultAbiCoder.encode(types, values);
-    return encodeITSWrappedPayload(wrapperType, chain, payload);
-}
-
-function encodeLinkToken(wrapperType, chain, tokenId, type, remoteAddress, localAddress, minter) {
-    const payload = defaultAbiCoder.encode(
-        ['uint256', 'bytes32', 'uint256', 'bytes', 'bytes', 'bytes'],
-        [MESSAGE_TYPE_LINK_TOKEN, tokenId, type, remoteAddress, localAddress, minter],
-    );
-    return encodeITSWrappedPayload(wrapperType, chain, payload);
-}
-
-function encodeInterchainTransfer(wrapperType, chain, tokenId, from, to, amount, data) {
-    const payload = defaultAbiCoder.encode(
+function encodeInterchainTransferMessage(tokenId, from, to, amount, data) {
+    return defaultAbiCoder.encode(
         ['uint256', 'bytes32', 'bytes', 'bytes', 'uint256', 'bytes'],
         [MESSAGE_TYPE_INTERCHAIN_TRANSFER, tokenId, from, to, amount, data],
     );
-    return encodeITSWrappedPayload(wrapperType, chain, payload);
 }
 
-function encodeDeployTokenManager(wrapperType, chain, tokenId, address, salt) {
-    const payload = defaultAbiCoder.encode(
-        ['uint256', 'bytes32', 'bytes', 'uint256'],
-        [MESSAGE_TYPE_DEPLOY_TOKEN_MANAGER, tokenId, address, salt],
+function encodeDeployInterchainTokenMessage(tokenId, name, symbol, decimals, minter) {
+    return defaultAbiCoder.encode(
+        ['uint256', 'bytes32', 'string', 'string', 'uint8', 'bytes'],
+        [MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN, tokenId, name, symbol, decimals, minter],
     );
-    return encodeITSWrappedPayload(wrapperType, chain, payload);
 }
 
-function encodeRegisterTokenMetadata(tokenAddress, decimals) {
-    const payload = defaultAbiCoder.encode(['uint256', 'bytes', 'uint8'], [MESSAGE_TYPE_REGISTER_TOKEN_METADATA, tokenAddress, decimals]);
+function encodeDeployTokenManagerMessage(tokenId, address, salt) {
+    return defaultAbiCoder.encode(['uint256', 'bytes32', 'bytes', 'uint256'], [MESSAGE_TYPE_DEPLOY_TOKEN_MANAGER, tokenId, address, salt]);
+}
+
+function encodeHubMessage(wrapperType, chain, message) {
+    const payload = defaultAbiCoder.encode(['uint256', 'string', 'bytes'], [wrapperType, chain, message]);
     return {
         payload,
         payloadHash: keccak256(payload),
     };
 }
 
-function encodeAndHashPayload(wrapperType, chain, payload) {
-    const wrappedPayload = defaultAbiCoder.encode(['uint256', 'string', 'bytes'], [wrapperType, chain, payload]);
-    return {
-        payload: wrappedPayload,
-        payloadHash: keccak256(wrappedPayload),
-    };
+function encodeLinkTokenMessage(tokenId, type, remoteAddress, localAddress, minter) {
+    return defaultAbiCoder.encode(
+        ['uint256', 'bytes32', 'uint256', 'bytes', 'bytes', 'bytes'],
+        [MESSAGE_TYPE_LINK_TOKEN, tokenId, type, remoteAddress, localAddress, minter],
+    );
 }
 
-function encodeITSWrappedPayload(wrapperType, chain, payload) {
-    if (Array.isArray(chain)) {
-        return chain.map((c) => encodeAndHashPayload(wrapperType, c, payload));
-    }
-
-    return encodeAndHashPayload(wrapperType, chain, payload);
+function encodeRegisterTokenMetadataMessage(tokenAddress, decimals) {
+    const payload = defaultAbiCoder.encode(['uint256', 'bytes', 'uint8'], [MESSAGE_TYPE_REGISTER_TOKEN_METADATA, tokenAddress, decimals]);
+    return {
+        payload,
+        payloadHash: keccak256(payload),
+    };
 }
 
 module.exports = {
@@ -266,10 +248,10 @@ module.exports = {
     gasReporter,
     getEVMVersion,
     getContractJSON,
-    encodeDeployInterchainToken,
-    encodeLinkToken,
-    encodeInterchainTransfer,
-    encodeDeployTokenManager,
-    encodeRegisterTokenMetadata,
-    encodeITSWrappedPayload,
+    encodeInterchainTransferMessage,
+    encodeDeployInterchainTokenMessage,
+    encodeDeployTokenManagerMessage,
+    encodeHubMessage,
+    encodeLinkTokenMessage,
+    encodeRegisterTokenMetadataMessage,
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -195,7 +195,7 @@ function getContractJSON(contractName, artifactPath) {
     }
 }
 
-function resolveMessageType(messageType, values) {
+function resolveITSMessageType(messageType, values) {
     switch (messageType) {
         case MESSAGE_TYPE_DEPLOY_INTERCHAIN_TOKEN:
             if (values.length === 7) {
@@ -224,7 +224,7 @@ function resolveMessageType(messageType, values) {
     }
 }
 
-function encodeITSWrappedPayload(wrapperType, chain, innerPayload) {
+function wrapPayload(wrapperType, chain, innerPayload) {
     const wrappedPayload = defaultAbiCoder.encode(['uint256', 'string', 'bytes'], [wrapperType, chain, innerPayload]);
     return {
         payload: wrappedPayload,
@@ -238,19 +238,18 @@ function encodeITSWrappedPayload(wrapperType, chain, innerPayload) {
  *
  * @param {number} wrapperType - Wrapper message type (e.g. RECEIVE_FROM_HUB, SEND_TO_HUB)
  * @param {string|string[]} chain - Single chain name or array of chains
- * @param {Array<any>} innerValues - Values for the ITS payload (first item must be messageType)
+ * @param {Array<any>} values - Values for the ITS payload (first item must be messageType)
  * @returns {{ payload: string, hash: string } | { payload: string, hash: string }[]} - Wrapped payload(s) and hash(es)
  */
-function encodeITSPayload(wrapperType, chain, innerValues) {
-    const messageType = innerValues[0];
-    const innerTypes = resolveMessageType(messageType, innerValues);
-    const innerPayload = defaultAbiCoder.encode(innerTypes, innerValues);
+function encodeITSPayload(wrapperType, chain, values) {
+    const messageType = resolveITSMessageType(values[0], values);
+    const payload = defaultAbiCoder.encode(messageType, values);
 
     if (Array.isArray(chain)) {
-        return chain.map((chain) => encodeITSWrappedPayload(wrapperType, chain, innerPayload));
+        return chain.map((chain) => wrapPayload(wrapperType, chain, payload));
     }
 
-    return encodeITSWrappedPayload(wrapperType, chain, innerPayload);
+    return wrapPayload(wrapperType, chain, payload);
 }
 
 module.exports = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -224,8 +224,8 @@ function resolveITSMessageType(messageType, values) {
     }
 }
 
-function wrapPayload(wrapperType, chain, innerPayload) {
-    const wrappedPayload = defaultAbiCoder.encode(['uint256', 'string', 'bytes'], [wrapperType, chain, innerPayload]);
+function wrapPayload(wrapperType, chain, payload) {
+    const wrappedPayload = defaultAbiCoder.encode(['uint256', 'string', 'bytes'], [wrapperType, chain, payload]);
     return {
         payload: wrappedPayload,
         payloadHash: keccak256(wrappedPayload),


### PR DESCRIPTION
[AXE-9171](https://axelarnetwork.atlassian.net/browse/AXE-9171)

[AXE-9171]: https://axelarnetwork.atlassian.net/browse/AXE-9171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ