### PR TITLE
docs: add security warning for express execute in natspec

### DIFF
--- a/contracts/executable/InterchainTokenExpressExecutable.sol
+++ b/contracts/executable/InterchainTokenExpressExecutable.sol
@@ -10,6 +10,11 @@ import { InterchainTokenExecutable } from './InterchainTokenExecutable.sol';
  * @notice Abstract contract that defines an interface for executing express logic in the context of interchain token operations.
  * @dev This contract extends `InterchainTokenExecutable` to provide express execution capabilities. It is intended to be inherited by contracts
  * that implement express logic for interchain token actions. This contract will only be called by the interchain token service.
+ *
+ * IMPORTANT: Unlike regular execute, express execute can be called by anyone willing to pay for the tokens upfront.
+ * This means the parameters passed to express execute are NOT validated by the GMP gateway.
+ * Only the token transfer itself should be considered to have value. The payload and any other metadata
+ * should NOT be used for anything critical beyond manipulating the received tokens.
  */
 abstract contract InterchainTokenExpressExecutable is IInterchainTokenExpressExecutable, InterchainTokenExecutable {
     bytes32 internal constant EXPRESS_EXECUTE_SUCCESS = keccak256('its-express-execute-success');

--- a/contracts/executable/InterchainTokenExpressExecutable.sol
+++ b/contracts/executable/InterchainTokenExpressExecutable.sol
@@ -11,7 +11,7 @@ import { InterchainTokenExecutable } from './InterchainTokenExecutable.sol';
  * @dev This contract extends `InterchainTokenExecutable` to provide express execution capabilities. It is intended to be inherited by contracts
  * that implement express logic for interchain token actions. This contract will only be called by the interchain token service.
  *
- * IMPORTANT: Unlike regular execute, express execute can be called by anyone willing to pay for the tokens upfront.
+ * IMPORTANT: Express execute can be called by anyone willing to pay for the tokens upfront.
  * This means the parameters passed to express execute are NOT validated by the GMP gateway.
  * Only the token transfer itself should be considered to have value. The payload and any other metadata
  * should NOT be used for anything critical beyond manipulating the received tokens.

--- a/contracts/interfaces/IInterchainTokenExpressExecutable.sol
+++ b/contracts/interfaces/IInterchainTokenExpressExecutable.sol
@@ -7,7 +7,7 @@ import { IInterchainTokenExecutable } from './IInterchainTokenExecutable.sol';
 /**
  * @title IInterchainTokenExpressExecutable
  * @notice Contracts should implement this interface to accept express calls from the InterchainTokenService.
- * @dev IMPORTANT: Unlike regular execute, express execute can be called by anyone willing to pay for the tokens upfront.
+ * @dev IMPORTANT: Express execute can be called by anyone willing to pay for the tokens upfront.
  * This means the parameters passed to express execute are NOT validated by the GMP gateway.
  * Only the token transfer itself should be considered to have value. The payload and any other metadata
  * should NOT be used for anything critical beyond manipulating the received tokens.

--- a/contracts/interfaces/IInterchainTokenExpressExecutable.sol
+++ b/contracts/interfaces/IInterchainTokenExpressExecutable.sol
@@ -7,6 +7,10 @@ import { IInterchainTokenExecutable } from './IInterchainTokenExecutable.sol';
 /**
  * @title IInterchainTokenExpressExecutable
  * @notice Contracts should implement this interface to accept express calls from the InterchainTokenService.
+ * @dev IMPORTANT: Unlike regular execute, express execute can be called by anyone willing to pay for the tokens upfront.
+ * This means the parameters passed to express execute are NOT validated by the GMP gateway.
+ * Only the token transfer itself should be considered to have value. The payload and any other metadata
+ * should NOT be used for anything critical beyond manipulating the received tokens.
  */
 interface IInterchainTokenExpressExecutable is IInterchainTokenExecutable {
     /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add NatSpec security warning about unvalidated express-execute parameters to `InterchainTokenExpressExecutable` and `IInterchainTokenExpressExecutable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16028f00ad6c069e43cc8aed458089e53ba91530. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->